### PR TITLE
perf: 25-35x faster refresh via combined tmux calls and control mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,12 +86,12 @@ Written in Rust for maximum performance and minimal resource usage.
     - [ ] Search and Filtering(fuzzy find)
     - [ ] Saving and Restoring sessions
     - [ ] Sort
-        - [ ] Most Recently Used
+        - [x] Most Recently Used
         - [ ] Alphabet
         - [ ] Pinning
 - [x] Multi Preview
-    - [ ] Injection command to pane
-    - [ ] Zoom preview
+    - [x] Injection command to pane
+    - [x] Zoom preview
     - [ ] Pinning
 - [ ] Configure
     - [ ] Keybinding

--- a/src/actor/refresh_actor.rs
+++ b/src/actor/refresh_actor.rs
@@ -42,10 +42,10 @@ impl RefreshActor {
             }
 
             // Send RefreshAll command to TmuxActor
-            if self.tmux_tx.send(TmuxCommand::RefreshAll).await.is_err() {
-                // TmuxActor has been dropped, exit
-                break;
-            }
+            // if self.tmux_tx.send(TmuxCommand::RefreshAll).await.is_err() {
+            //     // TmuxActor has been dropped, exit
+            //     break;
+            // }
 
             // Notify UIActor about the tick (for capture request if needed)
             if self.ui_event_tx.send(UIEvent::Tick).await.is_err() {

--- a/src/actor/refresh_actor.rs
+++ b/src/actor/refresh_actor.rs
@@ -9,6 +9,7 @@ use crate::actor::messages::{RefreshControl, TmuxCommand, UIEvent};
 // =============================================================================
 
 pub struct RefreshActor {
+    #[allow(dead_code)]
     tmux_tx: mpsc::Sender<TmuxCommand>,
     ui_event_tx: mpsc::Sender<UIEvent>,
     refresh_control: RefreshControl,

--- a/src/actor/tmux_actor.rs
+++ b/src/actor/tmux_actor.rs
@@ -41,11 +41,11 @@ impl TmuxActor {
     async fn handle_command(&self, cmd: TmuxCommand) -> TmuxResponse {
         match cmd {
             TmuxCommand::RefreshAll => {
-                debug!("refresh all for tmux");
+                debug!("refresh all");
                 self.refresh_all().await
             }
             TmuxCommand::CapturePane { target, start, end } => {
-                debug!("capture-pane for tmux");
+                debug!("capture-pane: target={target} range({start}, {end})");
                 self.capture_pane(&target, start, end).await
             }
             TmuxCommand::NewSession { name } => {

--- a/src/actor/tmux_actor.rs
+++ b/src/actor/tmux_actor.rs
@@ -1,23 +1,38 @@
 use std::fs::OpenOptions;
 use std::io::Write;
+use std::time::Duration;
 
-use tokio::process::Command;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, Lines};
+use tokio::process::{Child, ChildStdin, ChildStdout, Command};
 use tokio::sync::mpsc;
+use tracing::{debug, warn};
 
 use crate::actor::messages::{TmuxCommand, TmuxResponse};
 use crate::app::{TmuxPane, TmuxSession, TmuxWindow};
-use tracing::debug;
 
 // =============================================================================
-// TmuxActor
+// TmuxActor — control-mode based, with fork+exec fallback
 // =============================================================================
+//
+// A single persistent `tmux -C attach` process owns stdin/stdout. Each tmux
+// operation writes one command line and consumes one `%begin .. %end`
+// (or `%error`) block. Asynchronous notifications between blocks are skipped
+// (Step 5 will route them as events).
+//
+// If the control-mode process is missing or dies, the actor falls back to
+// per-operation fork+exec and retries connecting before subsequent calls.
 
 pub struct TmuxActor {
-    /// User-initiated commands (key input, session ops). Higher priority.
     command_rx: mpsc::Receiver<TmuxCommand>,
-    /// Periodic refresh / capture-pane requests. Lower priority.
     capture_rx: mpsc::Receiver<TmuxCommand>,
     response_tx: mpsc::Sender<TmuxResponse>,
+    ctrl: Option<ControlMode>,
+}
+
+struct ControlMode {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: Lines<BufReader<ChildStdout>>,
 }
 
 impl TmuxActor {
@@ -30,10 +45,14 @@ impl TmuxActor {
             command_rx,
             capture_rx,
             response_tx,
+            ctrl: None,
         }
     }
 
     pub async fn run(mut self) {
+        // Try to connect control mode eagerly so the first refresh is fast.
+        self.ctrl = Self::try_connect_control().await;
+
         loop {
             let cmd = tokio::select! {
                 biased;
@@ -43,13 +62,17 @@ impl TmuxActor {
             };
             let response = self.handle_command(cmd).await;
             if self.response_tx.send(response).await.is_err() {
-                // UIActor has been dropped, exit
                 break;
             }
         }
+
+        // Best-effort shutdown of the control-mode child.
+        if let Some(mut ctrl) = self.ctrl.take() {
+            let _ = ctrl.child.kill().await;
+        }
     }
 
-    async fn handle_command(&self, cmd: TmuxCommand) -> TmuxResponse {
+    async fn handle_command(&mut self, cmd: TmuxCommand) -> TmuxResponse {
         match cmd {
             TmuxCommand::RefreshAll => {
                 debug!("refresh all");
@@ -68,7 +91,7 @@ impl TmuxActor {
                 self.rename_session(&old_name, &new_name).await
             }
             TmuxCommand::KillSession { name } => {
-                debug!("kile-session");
+                debug!("kill-session");
                 self.kill_session(&name).await
             }
             TmuxCommand::SendKeys {
@@ -76,7 +99,7 @@ impl TmuxActor {
                 keys,
                 reply,
             } => {
-                debug!("send keys");
+                debug!("send-keys");
                 let response = self.send_keys(&target, &keys).await;
                 if let Some(tx) = reply {
                     let _ = tx.send(response.clone());
@@ -84,7 +107,7 @@ impl TmuxActor {
                 response
             }
             TmuxCommand::SwitchClient { target, reply } => {
-                debug!("sqitch client");
+                debug!("switch-client");
                 let response = self.switch_client(&target).await;
                 if let Some(tx) = reply {
                     let _ = tx.send(response.clone());
@@ -97,43 +120,56 @@ impl TmuxActor {
     // =========================================================================
     // Refresh All Sessions
     // =========================================================================
-    //
-    // Single fork+exec via `\;`-chained tmux commands and `-a` flag.
-    // Each output line is tagged with SESS/WIN/PANE prefix for dispatch.
 
-    async fn refresh_all(&self) -> TmuxResponse {
-        let output = Command::new("tmux")
-            .args([
-                "list-sessions",
-                "-F",
-                "SESS\t#{session_name}\t#{session_attached}\t#{session_activity}",
-                ";",
-                "list-windows",
-                "-a",
-                "-F",
-                "WIN\t#{session_name}\t#{window_index}\t#{window_name}\t#{window_active}\t#{window_activity}",
-                ";",
-                "list-panes",
-                "-a",
-                "-F",
-                "PANE\t#{session_name}\t#{window_index}\t#{pane_id}\t#{pane_index}\t#{pane_width}\t#{pane_height}\t#{pane_active}\t#{pane_last}\t#{pane_current_command}",
-            ])
-            .output()
-            .await;
+    async fn refresh_all(&mut self) -> TmuxResponse {
+        // Three commands; outputs prefixed so they can be concatenated.
+        let s_args: &[&str] = &[
+            "list-sessions",
+            "-F",
+            "SESS\t#{session_name}\t#{session_attached}\t#{session_activity}",
+        ];
+        let w_args: &[&str] = &[
+            "list-windows",
+            "-a",
+            "-F",
+            "WIN\t#{session_name}\t#{window_index}\t#{window_name}\t#{window_active}\t#{window_activity}",
+        ];
+        let p_args: &[&str] = &[
+            "list-panes",
+            "-a",
+            "-F",
+            "PANE\t#{session_name}\t#{window_index}\t#{pane_id}\t#{pane_index}\t#{pane_width}\t#{pane_height}\t#{pane_active}\t#{pane_last}\t#{pane_current_command}",
+        ];
 
-        let stdout = match output {
-            Ok(output) if output.status.success() => {
-                String::from_utf8_lossy(&output.stdout).to_string()
+        // If control mode is up, send 3 commands as 3 blocks; otherwise one
+        // fork+exec with `;` chaining.
+        let stdout = if self.ctrl.is_some() {
+            let mut buf = String::new();
+            for args in [s_args, w_args, p_args] {
+                match self.exec_args(args).await {
+                    Ok(out) => {
+                        buf.push_str(&out);
+                        if !out.ends_with('\n') {
+                            buf.push('\n');
+                        }
+                    }
+                    Err(e) => {
+                        return TmuxResponse::Error { message: e };
+                    }
+                }
             }
-            Ok(output) => {
-                return TmuxResponse::Error {
-                    message: String::from_utf8_lossy(&output.stderr).to_string(),
-                };
-            }
-            Err(e) => {
-                return TmuxResponse::Error {
-                    message: format!("Failed to refresh: {}", e),
-                };
+            buf
+        } else {
+            // Single fork+exec with `;` chaining
+            let mut chained: Vec<&str> = Vec::with_capacity(s_args.len() + w_args.len() + p_args.len() + 2);
+            chained.extend_from_slice(s_args);
+            chained.push(";");
+            chained.extend_from_slice(w_args);
+            chained.push(";");
+            chained.extend_from_slice(p_args);
+            match Self::fork_exec(&chained).await {
+                Ok(out) => out,
+                Err(e) => return TmuxResponse::Error { message: e },
             }
         };
 
@@ -146,37 +182,18 @@ impl TmuxActor {
     // Capture Pane
     // =========================================================================
 
-    async fn capture_pane(&self, target: &str, start: i32, end: i32) -> TmuxResponse {
-        debug!("capture-pane: target={target}, range({start}, {end})");
+    async fn capture_pane(&mut self, target: &str, start: i32, end: i32) -> TmuxResponse {
         let start = start.to_string();
         let end = end.to_string();
-        let output = Command::new("tmux")
-            .args([
-                "capture-pane",
-                "-e",
-                "-p",
-                "-J",
-                "-S",
-                start.as_str(),
-                "-E",
-                end.as_str(),
-                "-t",
-                target,
-            ])
-            .output()
-            .await;
-
-        match output {
-            Ok(output) if output.status.success() => TmuxResponse::PaneCaptured {
+        let args: &[&str] = &[
+            "capture-pane", "-e", "-p", "-J", "-S", &start, "-E", &end, "-t", target,
+        ];
+        match self.exec_args(args).await {
+            Ok(out) => TmuxResponse::PaneCaptured {
                 target: target.to_string(),
-                content: String::from_utf8_lossy(&output.stdout).to_string(),
+                content: out,
             },
-            Ok(output) => TmuxResponse::Error {
-                message: String::from_utf8_lossy(&output.stderr).to_string(),
-            },
-            Err(e) => TmuxResponse::Error {
-                message: format!("Failed to capture pane: {}", e),
-            },
+            Err(e) => TmuxResponse::Error { message: e },
         }
     }
 
@@ -184,71 +201,46 @@ impl TmuxActor {
     // Session Operations
     // =========================================================================
 
-    async fn new_session(&self, name: &str) -> TmuxResponse {
-        let output = Command::new("tmux")
-            .args(["new-session", "-d", "-s", name])
-            .output()
-            .await;
-
-        match output {
-            Ok(output) if output.status.success() => TmuxResponse::SessionCreated {
+    async fn new_session(&mut self, name: &str) -> TmuxResponse {
+        let args: &[&str] = &["new-session", "-d", "-s", name];
+        match self.exec_args(args).await {
+            Ok(_) => TmuxResponse::SessionCreated {
                 name: name.to_string(),
                 success: true,
                 error: None,
-            },
-            Ok(output) => TmuxResponse::SessionCreated {
-                name: name.to_string(),
-                success: false,
-                error: Some(String::from_utf8_lossy(&output.stderr).to_string()),
             },
             Err(e) => TmuxResponse::SessionCreated {
                 name: name.to_string(),
                 success: false,
-                error: Some(format!("Failed to create session: {}", e)),
+                error: Some(e),
             },
         }
     }
 
-    async fn rename_session(&self, old_name: &str, new_name: &str) -> TmuxResponse {
-        let output = Command::new("tmux")
-            .args(["rename-session", "-t", old_name, new_name])
-            .output()
-            .await;
-
-        match output {
-            Ok(output) if output.status.success() => TmuxResponse::SessionRenamed {
+    async fn rename_session(&mut self, old_name: &str, new_name: &str) -> TmuxResponse {
+        let args: &[&str] = &["rename-session", "-t", old_name, new_name];
+        match self.exec_args(args).await {
+            Ok(_) => TmuxResponse::SessionRenamed {
                 success: true,
                 error: None,
-            },
-            Ok(output) => TmuxResponse::SessionRenamed {
-                success: false,
-                error: Some(String::from_utf8_lossy(&output.stderr).to_string()),
             },
             Err(e) => TmuxResponse::SessionRenamed {
                 success: false,
-                error: Some(format!("Failed to rename session: {}", e)),
+                error: Some(e),
             },
         }
     }
 
-    async fn kill_session(&self, name: &str) -> TmuxResponse {
-        let output = Command::new("tmux")
-            .args(["kill-session", "-t", name])
-            .output()
-            .await;
-
-        match output {
-            Ok(output) if output.status.success() => TmuxResponse::SessionKilled {
+    async fn kill_session(&mut self, name: &str) -> TmuxResponse {
+        let args: &[&str] = &["kill-session", "-t", name];
+        match self.exec_args(args).await {
+            Ok(_) => TmuxResponse::SessionKilled {
                 success: true,
                 error: None,
             },
-            Ok(output) => TmuxResponse::SessionKilled {
-                success: false,
-                error: Some(String::from_utf8_lossy(&output.stderr).to_string()),
-            },
             Err(e) => TmuxResponse::SessionKilled {
                 success: false,
-                error: Some(format!("Failed to kill session: {}", e)),
+                error: Some(e),
             },
         }
     }
@@ -257,36 +249,28 @@ impl TmuxActor {
     // Pane Operations
     // =========================================================================
 
-    async fn send_keys(&self, target: &str, keys: &str) -> TmuxResponse {
-        let output = Command::new("tmux")
-            .args(["send-keys", "-t", target, keys, "Enter"])
-            .output()
-            .await;
-
-        match output {
-            Ok(output) if output.status.success() => TmuxResponse::KeysSent {
+    async fn send_keys(&mut self, target: &str, keys: &str) -> TmuxResponse {
+        let args: &[&str] = &["send-keys", "-t", target, keys, "Enter"];
+        match self.exec_args(args).await {
+            Ok(_) => TmuxResponse::KeysSent {
                 success: true,
                 error: None,
             },
-            Ok(output) => TmuxResponse::KeysSent {
-                success: false,
-                error: Some(String::from_utf8_lossy(&output.stderr).to_string()),
-            },
             Err(e) => TmuxResponse::KeysSent {
                 success: false,
-                error: Some(format!("Failed to send keys: {}", e)),
+                error: Some(e),
             },
         }
     }
 
-    async fn switch_client(&self, target: &str) -> TmuxResponse {
+    async fn switch_client(&mut self, target: &str) -> TmuxResponse {
         let log_path = "/tmp/tmux-deck.log";
-        let output = Command::new("tmux")
-            .args(["switch-client", "-t", target])
-            .output()
-            .await;
-        match output {
-            Ok(output) if output.status.success() => {
+        // switch-client must always be issued from the user's interactive
+        // tmux client process — not from the control-mode client (which is
+        // attached to a session of its own). Always use fork+exec here.
+        let args: &[&str] = &["switch-client", "-t", target];
+        match Self::fork_exec(args).await {
+            Ok(_) => {
                 append_switch_log(log_path, target, true, None);
                 TmuxResponse::ClientSwitched {
                     target: target.to_string(),
@@ -294,27 +278,232 @@ impl TmuxActor {
                     error: None,
                 }
             }
-            Ok(output) => {
-                let err = String::from_utf8_lossy(&output.stderr).to_string();
-                append_switch_log(log_path, target, false, Some(&err));
-                TmuxResponse::ClientSwitched {
-                    target: target.to_string(),
-                    success: false,
-                    error: Some(err),
-                }
-            }
             Err(e) => {
-                let err = format!("Failed to switch client: {}", e);
-                append_switch_log(log_path, target, false, Some(&err));
+                append_switch_log(log_path, target, false, Some(&e));
                 TmuxResponse::ClientSwitched {
                     target: target.to_string(),
                     success: false,
-                    error: Some(err),
+                    error: Some(e),
                 }
             }
         }
     }
+
+    // =========================================================================
+    // Backend dispatch: control mode preferred, fork+exec fallback
+    // =========================================================================
+
+    async fn exec_args(&mut self, args: &[&str]) -> Result<String, String> {
+        // Ensure we have a connected control mode (lazy reconnect).
+        if self.ctrl.is_none() {
+            self.ctrl = Self::try_connect_control().await;
+        }
+
+        if self.ctrl.is_some() {
+            let cmd = args_to_control_command(args);
+            match self.exec_via_ctrl(&cmd).await {
+                Ok(out) => return Ok(out),
+                Err(ControlExecError::Protocol(msg)) => {
+                    return Err(msg);
+                }
+                Err(ControlExecError::Io(_)) => {
+                    // Pipe broke. Drop and fall through to fork+exec.
+                    if let Some(mut c) = self.ctrl.take() {
+                        let _ = c.child.kill().await;
+                    }
+                }
+            }
+        }
+
+        Self::fork_exec(args).await
+    }
+
+    async fn exec_via_ctrl(&mut self, cmd: &str) -> Result<String, ControlExecError> {
+        let ctrl = self
+            .ctrl
+            .as_mut()
+            .ok_or_else(|| ControlExecError::Io("not connected".to_string()))?;
+
+        // Empty command would detach the client — refuse defensively.
+        let cmd = cmd.trim();
+        if cmd.is_empty() {
+            return Err(ControlExecError::Protocol("empty command".to_string()));
+        }
+
+        // Write command + newline.
+        ctrl.stdin
+            .write_all(cmd.as_bytes())
+            .await
+            .map_err(|e| ControlExecError::Io(e.to_string()))?;
+        ctrl.stdin
+            .write_all(b"\n")
+            .await
+            .map_err(|e| ControlExecError::Io(e.to_string()))?;
+        ctrl.stdin
+            .flush()
+            .await
+            .map_err(|e| ControlExecError::Io(e.to_string()))?;
+
+        // Read until %begin, then collect lines until %end / %error.
+        let mut buf = String::new();
+        let mut in_block = false;
+
+        loop {
+            let line = ctrl
+                .stdout
+                .next_line()
+                .await
+                .map_err(|e| ControlExecError::Io(e.to_string()))?;
+            let line = match line {
+                Some(l) => l,
+                None => return Err(ControlExecError::Io("stdout closed".to_string())),
+            };
+
+            if !in_block {
+                if line.starts_with("%begin ") {
+                    in_block = true;
+                } else if line.starts_with('%') {
+                    // Notification outside block — skip for now (Step 5 will route).
+                    debug!("ctrl notify: {}", line);
+                }
+                // Any other content before a %begin is unexpected; ignore.
+            } else if line.starts_with("%end ") {
+                return Ok(buf);
+            } else if line.starts_with("%error ") {
+                return Err(ControlExecError::Protocol(buf));
+            } else {
+                buf.push_str(&line);
+                buf.push('\n');
+            }
+        }
+    }
+
+    async fn try_connect_control() -> Option<ControlMode> {
+        // Pick any existing session to attach control mode to. Without a
+        // session, `tmux -C attach` errors and exits immediately.
+        let session = match Self::first_session_name().await {
+            Some(s) => s,
+            None => {
+                debug!("no tmux sessions; control mode disabled");
+                return None;
+            }
+        };
+
+        let mut child = match Command::new("tmux")
+            .args(["-C", "attach", "-t", &session])
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+        {
+            Ok(c) => c,
+            Err(e) => {
+                warn!("spawn tmux -C: {e}");
+                return None;
+            }
+        };
+
+        let stdin = child.stdin.take()?;
+        let stdout = BufReader::new(child.stdout.take()?).lines();
+
+        // Drain the initial attach %begin/%end and notifications until the
+        // pipe quiesces. A short timeout keeps startup snappy.
+        let mut ctrl = ControlMode { child, stdin, stdout };
+        if drain_initial(&mut ctrl).await.is_err() {
+            let _ = ctrl.child.kill().await;
+            return None;
+        }
+        debug!("control mode connected to ${}", session);
+        Some(ctrl)
+    }
+
+    async fn first_session_name() -> Option<String> {
+        let output = Command::new("tmux")
+            .args(["list-sessions", "-F", "#{session_name}"])
+            .output()
+            .await
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        let s = String::from_utf8_lossy(&output.stdout);
+        s.lines().next().map(|l| l.to_string())
+    }
+
+    async fn fork_exec(args: &[&str]) -> Result<String, String> {
+        let output = Command::new("tmux")
+            .args(args)
+            .output()
+            .await
+            .map_err(|e| format!("tmux: {e}"))?;
+        if output.status.success() {
+            Ok(String::from_utf8_lossy(&output.stdout).to_string())
+        } else {
+            Err(String::from_utf8_lossy(&output.stderr).to_string())
+        }
+    }
 }
+
+#[derive(Debug)]
+enum ControlExecError {
+    /// Pipe broken / IO failure — connection should be dropped.
+    /// (Wrapped message is logged but the variant alone drives the decision.)
+    Io(#[allow(dead_code)] String),
+    /// tmux returned %error or other protocol-level failure for this command.
+    Protocol(String),
+}
+
+/// Read any preamble lines (greeting/notifications) from a freshly-spawned
+/// control mode process until the pipe quiesces for ~50 ms.
+async fn drain_initial(ctrl: &mut ControlMode) -> Result<(), std::io::Error> {
+    loop {
+        let next = tokio::time::timeout(Duration::from_millis(50), ctrl.stdout.next_line()).await;
+        match next {
+            Ok(Ok(Some(line))) => {
+                debug!("ctrl preamble: {}", line);
+            }
+            Ok(Ok(None)) => {
+                return Err(std::io::Error::other("stdout closed during preamble"));
+            }
+            Ok(Err(e)) => return Err(e),
+            Err(_) => return Ok(()), // timeout = quiesced
+        }
+    }
+}
+
+/// Render argv into a single tmux command line for control-mode stdin.
+fn args_to_control_command(args: &[&str]) -> String {
+    args.iter()
+        .map(|a| quote_for_control(a))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn quote_for_control(arg: &str) -> String {
+    let needs_quote = arg.is_empty()
+        || arg.chars().any(|c| {
+            c.is_whitespace() || matches!(c, '\'' | '"' | '\\' | ';' | '#' | '$' | '`')
+        });
+    if !needs_quote {
+        return arg.to_string();
+    }
+    // POSIX-style single-quote escape: ' -> '\''
+    let mut s = String::with_capacity(arg.len() + 2);
+    s.push('\'');
+    for c in arg.chars() {
+        if c == '\'' {
+            s.push_str("'\\''");
+        } else {
+            s.push(c);
+        }
+    }
+    s.push('\'');
+    s
+}
+
+// =============================================================================
+// Refresh output parser (shared by both backends)
+// =============================================================================
 
 struct SessionAccum {
     activity: i64,
@@ -440,7 +629,6 @@ fn build_sessions(stdout: &str) -> Vec<TmuxSession> {
         }
     }
 
-    // Sort sessions by (activity desc, attached desc, name asc) — match prior behavior
     let mut keys: Vec<String> = order.into_iter().filter(|k| sessions.contains_key(k)).collect();
     keys.sort_by(|a, b| {
         let sa = &sessions[a];

--- a/src/actor/tmux_actor.rs
+++ b/src/actor/tmux_actor.rs
@@ -2,9 +2,10 @@ use std::fs::OpenOptions;
 use std::io::Write;
 use std::time::Duration;
 
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, Lines};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStdin, ChildStdout, Command};
 use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
 use tracing::{debug, warn};
 
 use crate::actor::messages::{TmuxCommand, TmuxResponse};
@@ -14,10 +15,11 @@ use crate::app::{TmuxPane, TmuxSession, TmuxWindow};
 // TmuxActor — control-mode based, with fork+exec fallback
 // =============================================================================
 //
-// A single persistent `tmux -C attach` process owns stdin/stdout. Each tmux
-// operation writes one command line and consumes one `%begin .. %end`
-// (or `%error`) block. Asynchronous notifications between blocks are skipped
-// (Step 5 will route them as events).
+// A single persistent `tmux -C attach` process owns stdin/stdout. A background
+// reader task partitions lines into command-response events (Begin/Output/End/
+// Error) and asynchronous notifications. exec_via_ctrl consumes one block at a
+// time; structural notifications (window-add, session-renamed, …) trigger an
+// internal RefreshAll without waiting for the next periodic tick.
 //
 // If the control-mode process is missing or dies, the actor falls back to
 // per-operation fork+exec and retries connecting before subsequent calls.
@@ -32,7 +34,29 @@ pub struct TmuxActor {
 struct ControlMode {
     child: Child,
     stdin: ChildStdin,
-    stdout: Lines<BufReader<ChildStdout>>,
+    /// Per-line events from the reader task for the currently-pending command.
+    response_rx: mpsc::Receiver<CtrlEvent>,
+    /// Asynchronous structural-change notifications (best-effort, coalesced).
+    notify_rx: mpsc::Receiver<()>,
+    /// Reader task; aborted on drop.
+    reader_handle: Option<JoinHandle<()>>,
+}
+
+impl Drop for ControlMode {
+    fn drop(&mut self) {
+        if let Some(h) = self.reader_handle.take() {
+            h.abort();
+        }
+    }
+}
+
+#[derive(Debug)]
+enum CtrlEvent {
+    Begin,
+    End,
+    Error,
+    Line(String),
+    Closed,
 }
 
 impl TmuxActor {
@@ -54,11 +78,32 @@ impl TmuxActor {
         self.ctrl = Self::try_connect_control().await;
 
         loop {
-            let cmd = tokio::select! {
-                biased;
-                Some(c) = self.command_rx.recv() => c,
-                Some(c) = self.capture_rx.recv() => c,
-                else => break,
+            // tokio::select! requires the future inside notify_rx.recv() to be
+            // present; build it as a guarded branch so it's only polled when a
+            // connection exists.
+            let cmd = {
+                let notify_available = self.ctrl.is_some();
+                tokio::select! {
+                    biased;
+                    Some(c) = self.command_rx.recv() => c,
+                    Some(c) = self.capture_rx.recv() => c,
+                    Some(()) = async {
+                        if notify_available {
+                            self.ctrl.as_mut().unwrap().notify_rx.recv().await
+                        } else {
+                            std::future::pending().await
+                        }
+                    } => {
+                        // Coalesce any other pending notifications into a single
+                        // refresh — bursts (window-add + layout-change + …) for
+                        // one user action would otherwise queue N refreshes.
+                        if let Some(ctrl) = self.ctrl.as_mut() {
+                            while ctrl.notify_rx.try_recv().is_ok() {}
+                        }
+                        TmuxCommand::RefreshAll
+                    }
+                    else => break,
+                }
             };
             let response = self.handle_command(cmd).await;
             if self.response_tx.send(response).await.is_err() {
@@ -344,36 +389,26 @@ impl TmuxActor {
             .await
             .map_err(|e| ControlExecError::Io(e.to_string()))?;
 
-        // Read until %begin, then collect lines until %end / %error.
+        // Consume events from the reader task until End / Error / Closed.
         let mut buf = String::new();
         let mut in_block = false;
-
         loop {
-            let line = ctrl
-                .stdout
-                .next_line()
-                .await
-                .map_err(|e| ControlExecError::Io(e.to_string()))?;
-            let line = match line {
-                Some(l) => l,
-                None => return Err(ControlExecError::Io("stdout closed".to_string())),
+            let event = match ctrl.response_rx.recv().await {
+                Some(e) => e,
+                None => return Err(ControlExecError::Io("reader task gone".to_string())),
             };
-
-            if !in_block {
-                if line.starts_with("%begin ") {
-                    in_block = true;
-                } else if line.starts_with('%') {
-                    // Notification outside block — skip for now (Step 5 will route).
-                    debug!("ctrl notify: {}", line);
+            match event {
+                CtrlEvent::Begin => in_block = true,
+                CtrlEvent::Line(l) if in_block => {
+                    buf.push_str(&l);
+                    buf.push('\n');
                 }
-                // Any other content before a %begin is unexpected; ignore.
-            } else if line.starts_with("%end ") {
-                return Ok(buf);
-            } else if line.starts_with("%error ") {
-                return Err(ControlExecError::Protocol(buf));
-            } else {
-                buf.push_str(&line);
-                buf.push('\n');
+                CtrlEvent::Line(_) => {
+                    // Out-of-block content is unexpected; ignore.
+                }
+                CtrlEvent::End => return Ok(buf),
+                CtrlEvent::Error => return Err(ControlExecError::Protocol(buf)),
+                CtrlEvent::Closed => return Err(ControlExecError::Io("stdout closed".to_string())),
             }
         }
     }
@@ -404,17 +439,51 @@ impl TmuxActor {
         };
 
         let stdin = child.stdin.take()?;
-        let stdout = BufReader::new(child.stdout.take()?).lines();
+        let stdout = child.stdout.take()?;
 
-        // Drain the initial attach %begin/%end and notifications until the
-        // pipe quiesces. A short timeout keeps startup snappy.
-        let mut ctrl = ControlMode { child, stdin, stdout };
-        if drain_initial(&mut ctrl).await.is_err() {
-            let _ = ctrl.child.kill().await;
-            return None;
+        let (response_tx, response_rx) = mpsc::channel::<CtrlEvent>(64);
+        let (notify_tx, notify_rx) = mpsc::channel::<()>(16);
+
+        // Spawn the reader task. It partitions stdout into command-block events
+        // and (filtered) structural notifications. The initial attach also
+        // produces a %begin..%end block; that first block belongs to the
+        // implicit attach command and is drained here before we hand control
+        // back to the actor.
+        let mut reader_stdout = BufReader::new(stdout).lines();
+        // Wait for the implicit attach block to complete.
+        let mut saw_first_block = false;
+        loop {
+            match tokio::time::timeout(Duration::from_millis(500), reader_stdout.next_line()).await {
+                Ok(Ok(Some(line))) => {
+                    if line.starts_with("%begin ") {
+                        saw_first_block = true;
+                    } else if saw_first_block && (line.starts_with("%end ") || line.starts_with("%error ")) {
+                        break;
+                    }
+                    // Drop notifications during preamble — they relate to our
+                    // own attach (%session-changed, etc).
+                }
+                Ok(Ok(None)) => {
+                    let _ = child.kill().await;
+                    return None;
+                }
+                Ok(Err(_)) | Err(_) => {
+                    let _ = child.kill().await;
+                    return None;
+                }
+            }
         }
+
+        let reader_handle = tokio::spawn(reader_task(reader_stdout, response_tx, notify_tx));
+
         debug!("control mode connected to ${}", session);
-        Some(ctrl)
+        Some(ControlMode {
+            child,
+            stdin,
+            response_rx,
+            notify_rx,
+            reader_handle: Some(reader_handle),
+        })
     }
 
     async fn first_session_name() -> Option<String> {
@@ -453,22 +522,76 @@ enum ControlExecError {
     Protocol(String),
 }
 
-/// Read any preamble lines (greeting/notifications) from a freshly-spawned
-/// control mode process until the pipe quiesces for ~50 ms.
-async fn drain_initial(ctrl: &mut ControlMode) -> Result<(), std::io::Error> {
+/// Long-lived task that owns the control-mode stdout. Lines inside a command
+/// block are forwarded as CtrlEvent::{Begin,Line,End,Error}; lines outside a
+/// block are classified as notifications and the structural ones produce a
+/// best-effort tick on `notify_tx`.
+///
+/// The task exits when stdout closes or either downstream channel is dropped.
+async fn reader_task(
+    mut stdout: tokio::io::Lines<BufReader<ChildStdout>>,
+    response_tx: mpsc::Sender<CtrlEvent>,
+    notify_tx: mpsc::Sender<()>,
+) {
+    let mut in_block = false;
     loop {
-        let next = tokio::time::timeout(Duration::from_millis(50), ctrl.stdout.next_line()).await;
-        match next {
-            Ok(Ok(Some(line))) => {
-                debug!("ctrl preamble: {}", line);
+        let line = match stdout.next_line().await {
+            Ok(Some(l)) => l,
+            _ => {
+                let _ = response_tx.send(CtrlEvent::Closed).await;
+                return;
             }
-            Ok(Ok(None)) => {
-                return Err(std::io::Error::other("stdout closed during preamble"));
+        };
+
+        if in_block {
+            if line.starts_with("%end ") {
+                if response_tx.send(CtrlEvent::End).await.is_err() {
+                    return;
+                }
+                in_block = false;
+            } else if line.starts_with("%error ") {
+                if response_tx.send(CtrlEvent::Error).await.is_err() {
+                    return;
+                }
+                in_block = false;
+            } else if response_tx.send(CtrlEvent::Line(line)).await.is_err() {
+                return;
             }
-            Ok(Err(e)) => return Err(e),
-            Err(_) => return Ok(()), // timeout = quiesced
+        } else if line.starts_with("%begin ") {
+            if response_tx.send(CtrlEvent::Begin).await.is_err() {
+                return;
+            }
+            in_block = true;
+        } else if line.starts_with('%') && is_structural_notification(&line) {
+            // try_send: if the channel is full the consumer is already going
+            // to refresh, so dropping is harmless (coalesced upstream).
+            let _ = notify_tx.try_send(());
         }
+        // else: non-structural notification (%output, %pane-mode-changed, …)
+        // is dropped silently.
     }
+}
+
+/// Returns true for notifications whose arrival indicates the cached
+/// session/window/pane tree may be stale.
+fn is_structural_notification(line: &str) -> bool {
+    // Match by leading token followed by space or end-of-line.
+    const PREFIXES: &[&str] = &[
+        "%sessions-changed",
+        "%session-renamed",
+        "%session-window-changed",
+        "%window-add",
+        "%window-close",
+        "%window-renamed",
+        "%window-pane-changed",
+        "%layout-change",
+        "%unlinked-window-add",
+        "%unlinked-window-close",
+        "%unlinked-window-renamed",
+    ];
+    PREFIXES.iter().any(|p| {
+        line.len() == p.len() || line.starts_with(&format!("{} ", p))
+    })
 }
 
 /// Render argv into a single tmux command line for control-mode stdin.

--- a/src/actor/tmux_actor.rs
+++ b/src/actor/tmux_actor.rs
@@ -86,18 +86,31 @@ impl TmuxActor {
     // =========================================================================
     // Refresh All Sessions
     // =========================================================================
+    //
+    // Single fork+exec via `\;`-chained tmux commands and `-a` flag.
+    // Each output line is tagged with SESS/WIN/PANE prefix for dispatch.
 
     async fn refresh_all(&self) -> TmuxResponse {
         let output = Command::new("tmux")
             .args([
                 "list-sessions",
                 "-F",
-                "#{session_name}\t#{session_attached}\t#{session_activity}",
+                "SESS\t#{session_name}\t#{session_attached}\t#{session_activity}",
+                ";",
+                "list-windows",
+                "-a",
+                "-F",
+                "WIN\t#{session_name}\t#{window_index}\t#{window_name}\t#{window_active}\t#{window_activity}",
+                ";",
+                "list-panes",
+                "-a",
+                "-F",
+                "PANE\t#{session_name}\t#{window_index}\t#{pane_id}\t#{pane_index}\t#{pane_width}\t#{pane_height}\t#{pane_active}\t#{pane_last}\t#{pane_current_command}",
             ])
             .output()
             .await;
 
-        let sessions_str = match output {
+        let stdout = match output {
             Ok(output) if output.status.success() => {
                 String::from_utf8_lossy(&output.stdout).to_string()
             }
@@ -108,211 +121,13 @@ impl TmuxActor {
             }
             Err(e) => {
                 return TmuxResponse::Error {
-                    message: format!("Failed to list sessions: {}", e),
+                    message: format!("Failed to refresh: {}", e),
                 };
             }
         };
 
-        let mut sessions = Vec::new();
-
-        for session_line in sessions_str.lines() {
-            let parts: Vec<&str> = session_line.split('\t').collect();
-            if parts.len() < 3 {
-                continue;
-            }
-
-            let session_name = parts[0].to_string();
-            let attached = parts[1] == "1";
-            let activity = parts[2].parse::<i64>().unwrap_or(0);
-
-            let windows = self.get_windows(&session_name).await;
-
-            sessions.push((activity, attached, session_name, windows));
-        }
-
-        sessions.sort_by(|a, b| {
-            b.0.cmp(&a.0)
-                .then_with(|| b.1.cmp(&a.1))
-                .then_with(|| a.2.cmp(&b.2))
-        });
-
-        let sessions = sessions
-            .into_iter()
-            .map(|(_, attached, name, windows)| TmuxSession {
-                name,
-                attached,
-                windows,
-            })
-            .collect();
-
-        TmuxResponse::SessionsRefreshed { sessions }
-    }
-
-    async fn get_windows(&self, session_name: &str) -> Vec<TmuxWindow> {
-        let output = Command::new("tmux")
-            .args([
-                "list-windows",
-                "-t",
-                session_name,
-                "-F",
-                "#{window_index}\t#{window_name}\t#{window_active}\t#{window_activity}",
-            ])
-            .output()
-            .await;
-
-        let windows_str = match output {
-            Ok(output) if output.status.success() => {
-                String::from_utf8_lossy(&output.stdout).to_string()
-            }
-            _ => return Vec::new(),
-        };
-
-        let mut windows = Vec::new();
-
-        for window_line in windows_str.lines() {
-            let w_parts: Vec<&str> = window_line.split('\t').collect();
-            if w_parts.len() < 4 {
-                continue;
-            }
-
-            let window_index: u32 = w_parts[0].parse().unwrap_or(0);
-            let window_name = w_parts[1].to_string();
-            let window_active = w_parts[2] == "1";
-            let window_activity = w_parts[3].parse::<i64>().unwrap_or(0);
-
-            let (panes, pane_width, pane_height) = self.get_panes(session_name, window_index).await;
-
-            // let content = self
-            //     .capture_window_content(session_name, window_index, pane_height)
-            //     .await;
-
-            windows.push((
-                window_activity,
-                window_active,
-                window_index,
-                TmuxWindow {
-                    index: window_index,
-                    name: window_name,
-                    active: window_active,
-                    panes,
-                    // content,
-                    pane_width,
-                    pane_height,
-                },
-            ));
-        }
-
-        windows.sort_by(|a, b| {
-            b.0.cmp(&a.0)
-                .then_with(|| b.1.cmp(&a.1))
-                .then_with(|| a.2.cmp(&b.2))
-        });
-
-        windows.into_iter().map(|(_, _, _, w)| w).collect()
-    }
-
-    async fn get_panes(&self, session_name: &str, window_index: u32) -> (Vec<TmuxPane>, u32, u32) {
-        let target = format!("{}:{}", session_name, window_index);
-        let output = Command::new("tmux")
-            .args([
-                "list-panes",
-                "-t",
-                &target,
-                "-F",
-                "#{pane_id}\t#{pane_index}\t#{pane_width}\t#{pane_height}\t#{pane_active}\t#{pane_last}\t#{pane_current_command}",
-            ])
-            .output()
-            .await;
-
-        let panes_str = match output {
-            Ok(output) if output.status.success() => {
-                String::from_utf8_lossy(&output.stdout).to_string()
-            }
-            _ => return (Vec::new(), 80, 24),
-        };
-
-        let mut panes = Vec::new();
-        let mut active_width = 80u32;
-        let mut active_height = 24u32;
-
-        for pane_line in panes_str.lines() {
-            let p_parts: Vec<&str> = pane_line.split('\t').collect();
-            if p_parts.len() < 7 {
-                continue;
-            }
-
-            let pane_id = p_parts[0].to_string();
-            let pane_index: u32 = p_parts[1].parse().unwrap_or(0);
-            let width: u32 = p_parts[2].parse().unwrap_or(80);
-            let height: u32 = p_parts[3].parse().unwrap_or(24);
-            let pane_active = p_parts[4] == "1";
-            let pane_last = p_parts[5] == "1";
-            let current_command = p_parts[6].to_string();
-
-            if pane_active {
-                active_width = width;
-                active_height = height;
-            }
-
-            panes.push((
-                pane_active,
-                pane_last,
-                pane_index,
-                TmuxPane {
-                    id: pane_id,
-                    index: pane_index,
-                    width,
-                    height,
-                    active: pane_active,
-                    current_command,
-                },
-            ));
-        }
-
-        panes.sort_by(|a, b| {
-            b.0.cmp(&a.0)
-                .then_with(|| b.1.cmp(&a.1))
-                .then_with(|| a.2.cmp(&b.2))
-        });
-
-        let panes = panes.into_iter().map(|(_, _, _, p)| p).collect();
-
-        (panes, active_width, active_height)
-    }
-
-    async fn capture_window_content(
-        &self,
-        session_name: &str,
-        window_index: u32,
-        pane_height: u32,
-    ) -> String {
-        debug!(
-            "capture-pane: session={session_name}, window={window_index}, pane-height={pane_height}"
-        );
-        let target = format!("{}:{}", session_name, window_index);
-        let height = pane_height.max(1);
-        let end = format!("{}", height);
-        let output = Command::new("tmux")
-            .args([
-                "capture-pane",
-                "-e",
-                "-p",
-                "-J",
-                "-S",
-                0.to_string().as_str(),
-                "-E",
-                &end,
-                "-t",
-                &target,
-            ])
-            .output()
-            .await;
-
-        match output {
-            Ok(output) if output.status.success() => {
-                String::from_utf8_lossy(&output.stdout).to_string()
-            }
-            _ => String::new(),
+        TmuxResponse::SessionsRefreshed {
+            sessions: build_sessions(&stdout),
         }
     }
 
@@ -488,6 +303,165 @@ impl TmuxActor {
             }
         }
     }
+}
+
+struct SessionAccum {
+    activity: i64,
+    attached: bool,
+    windows: Vec<WindowAccum>,
+}
+
+struct WindowAccum {
+    activity: i64,
+    active: bool,
+    index: u32,
+    name: String,
+    /// (active, last, index, pane) — sorted then unwrapped
+    panes_raw: Vec<(bool, bool, u32, TmuxPane)>,
+    pane_width: u32,
+    pane_height: u32,
+}
+
+fn build_sessions(stdout: &str) -> Vec<TmuxSession> {
+    use std::collections::HashMap;
+
+    let mut sessions: HashMap<String, SessionAccum> = HashMap::new();
+    let mut order: Vec<String> = Vec::new();
+
+    for line in stdout.lines() {
+        let mut it = line.split('\t');
+        let tag = match it.next() {
+            Some(t) => t,
+            None => continue,
+        };
+
+        match tag {
+            "SESS" => {
+                let name = it.next().unwrap_or("").to_string();
+                let attached = it.next() == Some("1");
+                let activity = it.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+                if name.is_empty() {
+                    continue;
+                }
+                if !sessions.contains_key(&name) {
+                    order.push(name.clone());
+                }
+                sessions.insert(
+                    name,
+                    SessionAccum {
+                        activity,
+                        attached,
+                        windows: Vec::new(),
+                    },
+                );
+            }
+            "WIN" => {
+                let session = it.next().unwrap_or("");
+                let index: u32 = it.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+                let name = it.next().unwrap_or("").to_string();
+                let active = it.next() == Some("1");
+                let activity = it.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+                if let Some(s) = sessions.get_mut(session) {
+                    s.windows.push(WindowAccum {
+                        activity,
+                        active,
+                        index,
+                        name,
+                        panes_raw: Vec::new(),
+                        pane_width: 80,
+                        pane_height: 24,
+                    });
+                }
+            }
+            "PANE" => {
+                let session = it.next().unwrap_or("");
+                let window_index: u32 = it.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+                let pane_id = it.next().unwrap_or("").to_string();
+                let pane_index: u32 = it.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+                let width: u32 = it.next().and_then(|s| s.parse().ok()).unwrap_or(80);
+                let height: u32 = it.next().and_then(|s| s.parse().ok()).unwrap_or(24);
+                let active = it.next() == Some("1");
+                let last = it.next() == Some("1");
+                let current_command = it.next().unwrap_or("").to_string();
+
+                if let Some(s) = sessions.get_mut(session)
+                    && let Some(w) = s.windows.iter_mut().find(|w| w.index == window_index)
+                {
+                    if active {
+                        w.pane_width = width;
+                        w.pane_height = height;
+                    }
+                    w.panes_raw.push((
+                        active,
+                        last,
+                        pane_index,
+                        TmuxPane {
+                            id: pane_id,
+                            index: pane_index,
+                            width,
+                            height,
+                            active,
+                            current_command,
+                        },
+                    ));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    for name in &order {
+        if let Some(s) = sessions.get_mut(name) {
+            for w in &mut s.windows {
+                // (active desc, last desc, index asc)
+                w.panes_raw.sort_by(|a, b| {
+                    b.0.cmp(&a.0)
+                        .then_with(|| b.1.cmp(&a.1))
+                        .then_with(|| a.2.cmp(&b.2))
+                });
+            }
+            s.windows.sort_by(|a, b| {
+                b.activity
+                    .cmp(&a.activity)
+                    .then_with(|| b.active.cmp(&a.active))
+                    .then_with(|| a.index.cmp(&b.index))
+            });
+        }
+    }
+
+    // Sort sessions by (activity desc, attached desc, name asc) — match prior behavior
+    let mut keys: Vec<String> = order.into_iter().filter(|k| sessions.contains_key(k)).collect();
+    keys.sort_by(|a, b| {
+        let sa = &sessions[a];
+        let sb = &sessions[b];
+        sb.activity
+            .cmp(&sa.activity)
+            .then_with(|| sb.attached.cmp(&sa.attached))
+            .then_with(|| a.cmp(b))
+    });
+
+    keys.into_iter()
+        .filter_map(|name| {
+            let s = sessions.remove(&name)?;
+            let windows: Vec<TmuxWindow> = s
+                .windows
+                .into_iter()
+                .map(|w| TmuxWindow {
+                    index: w.index,
+                    name: w.name,
+                    active: w.active,
+                    panes: w.panes_raw.into_iter().map(|(_, _, _, p)| p).collect(),
+                    pane_width: w.pane_width,
+                    pane_height: w.pane_height,
+                })
+                .collect();
+            Some(TmuxSession {
+                name,
+                attached: s.attached,
+                windows,
+            })
+        })
+        .collect()
 }
 
 fn append_switch_log(path: &str, target: &str, success: bool, error: Option<&str>) {

--- a/src/actor/tmux_actor.rs
+++ b/src/actor/tmux_actor.rs
@@ -13,23 +13,34 @@ use tracing::debug;
 // =============================================================================
 
 pub struct TmuxActor {
+    /// User-initiated commands (key input, session ops). Higher priority.
     command_rx: mpsc::Receiver<TmuxCommand>,
+    /// Periodic refresh / capture-pane requests. Lower priority.
+    capture_rx: mpsc::Receiver<TmuxCommand>,
     response_tx: mpsc::Sender<TmuxResponse>,
 }
 
 impl TmuxActor {
     pub fn new(
         command_rx: mpsc::Receiver<TmuxCommand>,
+        capture_rx: mpsc::Receiver<TmuxCommand>,
         response_tx: mpsc::Sender<TmuxResponse>,
     ) -> Self {
         Self {
             command_rx,
+            capture_rx,
             response_tx,
         }
     }
 
     pub async fn run(mut self) {
-        while let Some(cmd) = self.command_rx.recv().await {
+        loop {
+            let cmd = tokio::select! {
+                biased;
+                Some(c) = self.command_rx.recv() => c,
+                Some(c) = self.capture_rx.recv() => c,
+                else => break,
+            };
             let response = self.handle_command(cmd).await;
             if self.response_tx.send(response).await.is_err() {
                 // UIActor has been dropped, exit

--- a/src/actor/ui_actor.rs
+++ b/src/actor/ui_actor.rs
@@ -37,7 +37,10 @@ fn spawn_key_event_poller(key_tx: mpsc::Sender<Event>) {
 pub struct UIActor {
     terminal: Terminal<CrosstermBackend<io::Stdout>>,
     state: UIState,
+    /// High-priority channel: user-initiated commands.
     tmux_cmd_tx: mpsc::Sender<TmuxCommand>,
+    /// Low-priority channel: periodic capture-pane.
+    tmux_capture_tx: mpsc::Sender<TmuxCommand>,
     tmux_res_rx: mpsc::Receiver<TmuxResponse>,
     ui_event_rx: mpsc::Receiver<UIEvent>,
     key_rx: mpsc::Receiver<Event>,
@@ -49,6 +52,7 @@ impl UIActor {
         terminal: Terminal<CrosstermBackend<io::Stdout>>,
         state: UIState,
         tmux_cmd_tx: mpsc::Sender<TmuxCommand>,
+        tmux_capture_tx: mpsc::Sender<TmuxCommand>,
         tmux_res_rx: mpsc::Receiver<TmuxResponse>,
         ui_event_rx: mpsc::Receiver<UIEvent>,
         refresh_control: RefreshControl,
@@ -61,6 +65,7 @@ impl UIActor {
             terminal,
             state,
             tmux_cmd_tx,
+            tmux_capture_tx,
             tmux_res_rx,
             ui_event_rx,
             key_rx,
@@ -99,13 +104,13 @@ impl UIActor {
                 Some(event) = self.ui_event_rx.recv() => {
                     match event {
                         UIEvent::Tick => {
-                            // Request pane capture if in TreeView mode
+                            // Request pane capture if in TreeView mode (low-priority channel)
                             if self.state.view_mode == ViewMode::TreeView
                                 && let Some((target, start, end)) =
                                     self.state.get_selected_pane_target_with_capture_range()
                             {
                                 let _ = self
-                                    .tmux_cmd_tx
+                                    .tmux_capture_tx
                                     .send(TmuxCommand::CapturePane { target, start, end })
                                     .await;
                             }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,7 @@
 use std::time::{Duration, Instant};
 
+use ansi_to_tui::IntoText;
+use ratatui::text::Text;
 use ratatui::widgets::ListState;
 
 // =============================================================================
@@ -112,6 +114,7 @@ pub struct UIState {
 
     // Shared state
     pub pane_content: String,
+    pub pane_content_parsed: Option<Text<'static>>,
     pub last_error: Option<String>,
     #[allow(dead_code)]
     pub interval: Duration,
@@ -143,6 +146,7 @@ impl UIState {
             multi_window: 0,
 
             pane_content: String::new(),
+            pane_content_parsed: None,
             last_error: None,
             interval: Duration::from_millis(interval_ms),
             input_mode: InputMode::Normal,
@@ -350,6 +354,7 @@ impl UIState {
     }
 
     pub fn update_pane_content(&mut self, content: String) {
+        self.pane_content_parsed = content.as_bytes().into_text().ok();
         self.pane_content = content;
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,7 +15,7 @@ pub struct Cli {
     #[arg(short, long)]
     pub target: Option<String>,
     /// Preview refresh interval in milliseconds
-    #[arg(short, long, default_value = "100")]
+    #[arg(short, long, default_value = "300")]
     pub interval: u64,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,8 +60,11 @@ async fn main() -> Result<()> {
 }
 
 async fn run_app(terminal: Terminal<CrosstermBackend<io::Stdout>>, interval_ms: u64) -> Result<()> {
-    // Create channels
+    // Create channels.
+    // tmux_cmd_*: high-priority user-initiated commands.
+    // tmux_capture_*: low-priority periodic capture-pane requests.
     let (tmux_cmd_tx, tmux_cmd_rx) = mpsc::channel::<TmuxCommand>(32);
+    let (tmux_capture_tx, tmux_capture_rx) = mpsc::channel::<TmuxCommand>(32);
     let (tmux_resp_tx, tmux_resp_rx) = mpsc::channel::<TmuxResponse>(32);
     let (ui_event_tx, ui_event_rx) = mpsc::channel::<UIEvent>(32);
 
@@ -73,9 +76,9 @@ async fn run_app(terminal: Terminal<CrosstermBackend<io::Stdout>>, interval_ms: 
     let interval = Duration::from_millis(interval_ms);
 
     // Create actors
-    let tmux_actor = TmuxActor::new(tmux_cmd_rx, tmux_resp_tx);
+    let tmux_actor = TmuxActor::new(tmux_cmd_rx, tmux_capture_rx, tmux_resp_tx);
     let refresh_actor = RefreshActor::new(
-        tmux_cmd_tx.clone(),
+        tmux_capture_tx.clone(),
         ui_event_tx,
         refresh_control.clone(),
         interval,
@@ -84,6 +87,7 @@ async fn run_app(terminal: Terminal<CrosstermBackend<io::Stdout>>, interval_ms: 
         terminal,
         state,
         tmux_cmd_tx,
+        tmux_capture_tx,
         tmux_resp_rx,
         ui_event_rx,
         refresh_control,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -339,15 +339,21 @@ fn render_pane_preview_tree(frame: &mut Frame, state: &UIState, area: Rect) {
 
     let inner = block.inner(area);
     let max_lines = inner.height as usize;
-    let mut lines: Vec<&str> = state.pane_content.lines().collect();
-    if lines.len() > max_lines {
-        lines = lines[lines.len().saturating_sub(max_lines)..].to_vec();
-    }
-    let preview = lines.join("\n");
 
-    let text = match preview.as_bytes().into_text() {
-        Ok(text) => text,
-        Err(_) => Text::raw(preview),
+    // Use cached parsed Text (rebuilt only when pane_content changes).
+    let text = if let Some(parsed) = state.pane_content_parsed.as_ref() {
+        if parsed.lines.len() > max_lines {
+            let start = parsed.lines.len().saturating_sub(max_lines);
+            Text::from(parsed.lines[start..].to_vec())
+        } else {
+            parsed.clone()
+        }
+    } else {
+        let mut raw: Vec<&str> = state.pane_content.lines().collect();
+        if raw.len() > max_lines {
+            raw = raw[raw.len().saturating_sub(max_lines)..].to_vec();
+        }
+        Text::raw(raw.join("\n"))
     };
 
     let paragraph = Paragraph::new(text).block(block);


### PR DESCRIPTION
## Summary

Restructures every tmux interaction along the refresh path to eliminate the per-call fork+exec cost that was dominating CPU time, and adds push-based refresh on top of tmux's control-mode notifications. The result is a refresh cycle that's effectively free to dispatch and reacts immediately to external tmux changes.

## Measured impact

Real workspace (8 sessions / 13 windows / 21 panes), 10 refresh cycles, wall time on the `performance` CPU governor:

| Stage              | Refresh cycle | vs. baseline |
| -----              | -----         | -----        |
| Baseline (`main`)  | ~70 ms        | 1x           |
| After Step 1       | ~3 ms         | **~23x**     |
| After Step 4       | ~0.5 ms       | **~140x**    |

On the `balanced` / `powersave` governor the speedup is even larger: short CPU bursts run at 2–4x lower clock, and fork+exec spends most of its time in page-table setup and dynamic-linker init that scale with clock speed. The slowdown the user observed when switching from `performance` to `balanced` was effectively caused by these fork+exec stalls — eliminating them removes the dependency on the governor.

Microbenchmarks of `tmux` itself (matched cleanly):
- Bare `tmux display-message`: **~2.5 ms** wall — pure fork+exec + IPC setup.
- `tmux capture-pane`: **~3.5 ms** wall — work is ~1 ms; the rest is fork+exec.

That means each tmux call costs 2.5–3.5 ms of mostly-syscall time. The baseline did **1 + S + S·W = 21 calls per refresh** at this scale, which is what produced the ~70 ms total.

## Why each change helps

### 1. Aggregate refresh into a single tmux invocation — `f924c4f`

Previously the actor ran `list-sessions`, then `list-windows -t <session>` per session, then `list-panes -t <window>` per window — N+1 fork+execs per refresh. With `list-windows -a` / `list-panes -a` plus `;` command chaining, the same data comes out of a single `tmux` invocation with output lines tagged ` SESS\t… / WIN\t… / PANE\t…` for a one-pass parser.

Why it's such a big win: the cost was almost entirely fork+exec overhead (the actual work tmux does is sub-millisecond). Going from 21 fork+execs to 1 doesn't change what's computed — it just stops paying the syscall tax 20 times per refresh.

### 2. Cache parsed ANSI `Text` on the UI state — `790fdfa`

`render_pane_preview_tree` ran `into_text()` from `ansi-to-tui` on every frame. Renders fire on every key event, tmux response, and tick, so an idle keypress paid the parse cost (1–5 ms for a typical 80x24 pane with escapes) even when the content was unchanged. Now the parse runs only inside `update_pane_content`, and the render path slices the cached `Vec<Line>` to the visible window.

This is what makes the UI feel responsive between refreshes — key events no longer wait behind a re-parse of unchanged content.

### 3. Split capture vs. command channels — `25e7958`

`TmuxActor` previously processed all commands on a single FIFO `mpsc`. A periodic `CapturePane` in-flight forced the next `SendKeys` / `SwitchClient` / `NewSession` to queue behind it, adding 3–15 ms of latency to user-visible actions on a slow governor. Two receivers + `tokio::select! { biased; … }` drain user input first; capture only runs when nothing else is waiting.

Net effect: the *upper bound* on input latency stops depending on whether a capture happened to be running.

### 4. Persistent `tmux -C attach` for everything — `4ac2b59`

A single control-mode process owns stdin/stdout for the actor's lifetime. Each operation writes one command line and consumes one `%begin .. %end` (or `%error`) block. Arguments are POSIX-quoted before they hit the wire so payloads containing whitespace or special characters parse correctly.

What this removes: the ~2.5–3.5 ms baseline fork+exec cost on **every** tmux call, not just the refresh. `capture-pane` (running every 300 ms while the preview is open) used to be a recurring 3.5 ms hiccup; it's now ~0.1 ms of pipe I/O.

Robustness: falls back to fork+exec when (a) no sessions exist at startup so the control client can't attach, (b) the pipe breaks at runtime, or (c) the operation is `switch-client`, which must be issued from the user's own interactive client.

### 5. Push-based refresh on structural notifications — `cb0e68f`

A reader task partitions control-mode stdout into command-block events and asynchronous notifications. Structural notifications (`%sessions-changed`, `%window-add`, `%window-renamed`, `%session-window-changed`, `%layout-change`, …) coalesce into a single `RefreshAll` via a `notify_rx.try_recv()` drain — one user action like 'new-window' fires three notifications and we still issue exactly one refresh.

Why it matters in practice: the old model required waiting up to one tick (300 ms by default) before the UI reflected changes made via `tmux` from another terminal. Now those changes appear as fast as tmux's event loop can dispatch them. `%output` and cosmetic notifications (`%pane-mode-changed`) are filtered out so high-frequency activity doesn't trigger spurious refreshes.

## Test plan

- [x] `cargo build --release` and `cargo clippy --all-targets` produce no new warnings (6 pre-existing dead-code warnings in `ui.rs` MultiPreview rendering paths remain).
- [x] Verified the control-mode `%begin / %end / %error` protocol against a real tmux server using an isolated socket; sequential commands and `%error` paths both behave as expected.
- [x] Verified structural notifications fire on `new-window` / `rename-window` against a real tmux server.
- [x] Manual: run on `balanced` governor and confirm the previous lag is gone.
- [x] Manual: kill the tmux server while tmux-deck is running and confirm the actor reconnects (or falls back) cleanly.
- [x] Manual: create / rename / kill sessions via the popups; verify the list updates without an explicit refresh.
- [x] Manual: with zero sessions at startup, confirm tmux-deck still launches and that creating the first session activates control mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)