### PR TITLE
feat: Claude Code hook-driven treeview markers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -779,6 +779,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -796,6 +805,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -989,7 +1011,7 @@ dependencies = [
 
 [[package]]
 name = "tmux-deck"
-version = "0.0.0"
+version = "0.1.8"
 dependencies = [
  "ansi-to-tui",
  "clap",
@@ -998,6 +1020,7 @@ dependencies = [
  "crossterm",
  "directories",
  "ratatui",
+ "serde_json",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1339,3 +1362,9 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1011,7 +1011,7 @@ dependencies = [
 
 [[package]]
 name = "tmux-deck"
-version = "0.1.8"
+version = "0.0.0"
 dependencies = [
  "ansi-to-tui",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tmux-deck"
-version = "0.1.8"
+version = "0.0.0"
 edition = "2024"
 authors = ["tkcd <goriponikeike55@gmail.com>"]
 repository = "https://github.com/takeshid/tmux-deck"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ clap-cargo = "0.18.3"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter", "local-time"] }
 directories = "6.0.0"
+serde_json = "1"
 
 [[bin]]
 name = "tmux-deck"

--- a/README.md
+++ b/README.md
@@ -66,9 +66,10 @@ if youde use flake, you can add `tmux-deck` in your flake.nix
 
 # Claude Code Integration
 
-tmux-deck shows what [Claude Code](https://code.claude.com) is *doing* in each
-tmux pane, driven by Claude's **hooks**. Once the hooks are installed, the
-treeview marker reflects Claude's current state:
+tmux-deck highlights tmux entities that are running [Claude Code](https://code.claude.com).
+By default it detects the `claude` process and shows an orange `●`. If you also
+install the Claude **hooks**, the marker reflects what Claude is *doing* in each
+pane:
 
 | Marker | State | Meaning |
 | ------ | ----- | ------- |
@@ -76,10 +77,10 @@ treeview marker reflects Claude's current state:
 | `◆` (yellow) | Waiting | Claude is waiting on you (permission / idle prompt) |
 | `●` (green) | Done | Claude finished its turn |
 | `✗` (red) | Error | The turn ended with an error |
+| `●` (orange) | Running | Claude process detected, no hook state yet |
 
 Windows and sessions roll up to the most attention-worthy state of their
-children (waiting > error > working > done). No marker is shown until the
-hooks are installed.
+children (waiting > error > working > done).
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Monitoring multi session Realtime preview.
 - 🗂️ Tmux Session Management(New, Rename, Kill)
 - 📄 Easy management Windows and Panes between Sessions
 - 👀 Realtime Preview
+- 🤖 Claude Code status markers (working / waiting / done) driven by hooks
 - ⚙️ Easy Configure
 
 # Quick Start
@@ -62,6 +63,46 @@ if youde use flake, you can add `tmux-deck` in your flake.nix
   };
 }
 ```
+
+# Claude Code Integration
+
+tmux-deck highlights tmux entities that are running [Claude Code](https://code.claude.com).
+By default it detects the `claude` process and shows an orange `●`. If you also
+install the Claude **hooks**, the marker reflects what Claude is *doing* in each
+pane:
+
+| Marker | State | Meaning |
+| ------ | ----- | ------- |
+| `⠋⠙⠹…` (orange, animated) | Working | A prompt was submitted / a tool is running |
+| `◆` (yellow) | Waiting | Claude is waiting on you (permission / idle prompt) |
+| `●` (green) | Done | Claude finished its turn |
+| `✗` (red) | Error | The turn ended with an error |
+| `●` (orange) | Running | Claude process detected, no hook state yet |
+
+Windows and sessions roll up to the most attention-worthy state of their
+children (waiting > error > working > done).
+
+## Setup
+
+Install the hooks into Claude Code's user settings (`~/.claude/settings.json`):
+
+```bash
+tmux-deck hook install
+```
+
+Use `--project` to write to the project-local `.claude/settings.json` instead.
+The command is idempotent and preserves any existing settings.
+
+### How it works
+
+`hook install` registers `tmux-deck hook report` for the `UserPromptSubmit`,
+`PreToolUse`, `PostToolUse`, `Notification`, `Stop`, `SubagentStop` and
+`SessionEnd` events. On each event Claude runs the reporter, which records the
+calling pane's state (keyed by `$TMUX_PANE`) under
+`$XDG_STATE_HOME/tmux-deck/claude/`. The TUI reads those files on each refresh
+and updates the markers. Stale files are cleaned up automatically, and nothing
+is shown for panes that never ran Claude — so the integration is entirely
+opt-in.
 
 # Comparison with Similar Project
 
@@ -120,7 +161,8 @@ Written in Rust for maximum performance and minimal resource usage.
     - [ ] Layout
     - [ ] Color Theme
 - Misc
-    - [ ] LLM Integration
+    - [x] LLM Integration
+        - [x] Claude Code status markers via hooks
     - [ ] Installation for nix
 
 # License

--- a/README.md
+++ b/README.md
@@ -66,10 +66,9 @@ if youde use flake, you can add `tmux-deck` in your flake.nix
 
 # Claude Code Integration
 
-tmux-deck highlights tmux entities that are running [Claude Code](https://code.claude.com).
-By default it detects the `claude` process and shows an orange `●`. If you also
-install the Claude **hooks**, the marker reflects what Claude is *doing* in each
-pane:
+tmux-deck shows what [Claude Code](https://code.claude.com) is *doing* in each
+tmux pane, driven by Claude's **hooks**. Once the hooks are installed, the
+treeview marker reflects Claude's current state:
 
 | Marker | State | Meaning |
 | ------ | ----- | ------- |
@@ -77,10 +76,10 @@ pane:
 | `◆` (yellow) | Waiting | Claude is waiting on you (permission / idle prompt) |
 | `●` (green) | Done | Claude finished its turn |
 | `✗` (red) | Error | The turn ended with an error |
-| `●` (orange) | Running | Claude process detected, no hook state yet |
 
 Windows and sessions roll up to the most attention-worthy state of their
-children (waiting > error > working > done).
+children (waiting > error > working > done). No marker is shown until the
+hooks are installed.
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -67,17 +67,18 @@ if youde use flake, you can add `tmux-deck` in your flake.nix
 # Claude Code Integration
 
 tmux-deck highlights tmux entities that are running [Claude Code](https://code.claude.com).
-By default it detects the `claude` process and shows an orange `●`. If you also
-install the Claude **hooks**, the marker reflects what Claude is *doing* in each
-pane:
+By default it detects the `claude` process and shows a `●`. If you also install
+the Claude **hooks**, the marker reflects what Claude is *doing* in each pane.
+States are distinguished by the marker **shape** (the colour is always the
+same), so they stay legible on any terminal palette:
 
 | Marker | State | Meaning |
 | ------ | ----- | ------- |
-| `⠋⠙⠹…` (orange, animated) | Working | A prompt was submitted / a tool is running |
-| `◆` (yellow) | Waiting | Claude is waiting on you (permission / idle prompt) |
-| `●` (green) | Done | Claude finished its turn |
-| `✗` (red) | Error | The turn ended with an error |
-| `●` (orange) | Running | Claude process detected, no hook state yet |
+| `⠋⠙⠹…` (animated) | Working | A prompt was submitted / a tool is running |
+| `◆` | Waiting | Claude is waiting on you (permission / idle prompt) |
+| `✓` | Done | Claude finished its turn |
+| `✗` | Error | The turn ended with an error |
+| `●` | Running | Claude process detected, no hook state yet |
 
 Windows and sessions roll up to the most attention-worthy state of their
 children (waiting > error > working > done).

--- a/docs/claude-hook-treeview-plan.md
+++ b/docs/claude-hook-treeview-plan.md
@@ -1,0 +1,177 @@
+# 計画: Claude hook によるツリービューマーカーの動的変化
+
+## 目的
+
+tmux-deck のツリービュー（sessions / windows / panes の3リスト）に表示する
+Claude マーカーを、Claude Code の **hook イベント**が報告する状態
+（作業中・入力待ち・完了・エラー等）に応じて、記号と色で出し分ける。
+
+現状は「Claude プロセスが動いているか / いないか」の 2 状態のみ
+（オレンジの `●`）。これを多状態化して、ユーザーがどのセッションが
+注目を必要としているか（許可待ち・完了）を一目で把握できるようにする。
+
+## 現状の実装（参照）
+
+- `src/actor/tmux_actor.rs:844` `annotate_claude_panes()`
+  `ps -eo pid=,ppid=,args=` でプロセスツリーを走査し、pane の子孫に
+  `claude` プロセスがあれば `has_claude = true` をセット。
+- `src/app.rs:13-60` `TmuxPane / TmuxWindow / TmuxSession` が
+  `has_claude: bool` を保持。
+- `src/ui.rs:8-13` 定数 `CLAUDE_MARKER = "●"`,
+  `CLAUDE_MARKER_COLOR = Color::Indexed(208)`（オレンジ）。
+  `render_sessions_list` / `render_windows_list` / `render_panes_list` が
+  `has_claude` のとき `●` を付与。
+
+## Claude Code の hook 概要
+
+### 利用するイベント（要：実装前に公式ドキュメントで最終確定）
+
+公式: https://code.claude.com/docs/en/hooks.md
+
+| イベント | 発火タイミング | 遷移先の状態 |
+|---|---|---|
+| `UserPromptSubmit` | プロンプト送信時（処理開始前） | Working |
+| `PreToolUse` / `PostToolUse` | ツール実行前後（matcher 絞り込み可） | Working（継続） |
+| `Stop` | Claude が応答を完了したとき | Idle/Done |
+| `Notification` | 許可待ち / アイドル待ちの通知時 | Waiting（要注目） |
+| `SubagentStop` | サブエージェント終了時 | 補助 |
+| `SessionStart` / `SessionEnd` | セッション開始 / 終了 | 状態の初期化 / クリア |
+
+> 注: 調査では `StopFailure` などの追加イベントも候補に挙がったが
+> 確実性が低いため、実装着手時に公式ドキュメントで存在と入力スキーマを
+> 確定してから採用する。確定までは上記の安定イベントで設計する。
+
+### hook が受け取る入力（stdin の JSON）
+
+共通フィールド: `session_id`, `cwd`, `transcript_path`,
+`hook_event_name`, `permission_mode`。
+
+- `Stop`: `stop_reason`（`end_turn` 等）
+- `Notification`: `notification_type`（`permission_prompt` / `idle_prompt` 等）
+
+### インストール方法
+
+hook は `settings.json` の `hooks` キーで定義。優先順位（高い順）:
+
+1. `.claude/settings.local.json`（プロジェクト・gitignore）
+2. `.claude/settings.json`（プロジェクト・コミット可）
+3. `~/.claude/settings.json`（ユーザーグローバル）
+
+設定例:
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      { "hooks": [{ "type": "command", "command": "tmux-deck hook report" }] }
+    ],
+    "Stop": [
+      { "hooks": [{ "type": "command", "command": "tmux-deck hook report" }] }
+    ],
+    "Notification": [
+      { "hooks": [{ "type": "command", "command": "tmux-deck hook report" }] }
+    ],
+    "SubagentStop": [
+      { "hooks": [{ "type": "command", "command": "tmux-deck hook report" }] }
+    ],
+    "SessionEnd": [
+      { "hooks": [{ "type": "command", "command": "tmux-deck hook report" }] }
+    ]
+  }
+}
+```
+
+hook コマンドは終了コード 0 で正常。stdin から JSON を受け取る。
+
+## 設計
+
+### 連携の鍵: `$TMUX_PANE`
+
+hook スクリプト（= `tmux-deck hook report`）は Claude のサブプロセスとして
+その pane の環境で実行されるため、環境変数 **`$TMUX_PANE`**（例 `%3`）を
+読める。Claude の `session_id` は tmux pane と無関係なので、`$TMUX_PANE` を
+キーにして「どの hook イベントがどの tmux pane に属するか」を結びつける。
+`$TMUX_PANE` が無い（tmux 外で起動）場合は何もせず正常終了する。
+
+### 状態ファイル（決定: `$XDG_STATE_HOME`）
+
+- 保存先: `${XDG_STATE_HOME:-~/.local/state}/tmux-deck/claude/<pane_id>.json`
+  - `<pane_id>` は `$TMUX_PANE` の `%` を除いたもの等、ファイル名に安全な形へ正規化。
+- 内容例:
+
+  ```json
+  { "state": "waiting", "ts": 1730000000, "reason": "idle_prompt", "session_id": "..." }
+  ```
+
+- `ts` は更新時刻（epoch 秒）。一定時間（例: 6 時間）更新が無いもの、
+  および対応する pane が存在しないものは tmux-deck 側でクリーンアップ。
+
+### データフロー
+
+```
+Claude の状態変化
+  → hook 発火 → `tmux-deck hook report` 実行
+      → stdin の JSON をパース + $TMUX_PANE 取得
+      → 状態ファイル書き込み（pane 単位）
+
+tmux-deck 本体
+  → refresh 時に状態ディレクトリを走査
+  → pane.id でマッチング → ClaudeState を pane に付与
+  → window / session は子の「最も注目すべき」状態へ集約
+  → ui.rs が状態 → (記号, 色) を出し分けて描画
+```
+
+### 状態定義 `ClaudeState`
+
+| 状態 | 由来 | マーク | 色（案） |
+|---|---|---|---|
+| `Working` | `UserPromptSubmit` / `PreToolUse` | `●` | オレンジ (208) |
+| `Waiting` | `Notification`(permission/idle) | `◆` | 黄 |
+| `Idle` / `Done` | `Stop` (end_turn) | `●` | 緑 |
+| `Error` | （要確認）`StopFailure` 等 | `✗` | 赤 |
+| `Unknown` | プロセス検出のみ（hook 未設定） | `●` | グレー / オレンジ |
+
+- hook 状態を優先し、無ければ既存のプロセス検出（`has_claude`）に
+  フォールバックする。これにより hook 未設定環境でも従来どおり動作。
+- window / session への集約は注目度順
+  （Waiting > Error > Working > Done > Unknown など）で最大値を採用。
+
+## 実装ステップ（次フェーズ）
+
+1. **CLI サブコマンド追加** (`src/cli.rs`)
+   - `tmux-deck hook report` … hook 本体（stdin を受けて状態ファイル書込）
+   - `tmux-deck hook install [--user|--project]` … settings.json へ自動追記
+     （デフォルト: `--user` = `~/.claude/settings.json`）
+2. **`hook report` 実装**
+   - stdin JSON パース + `$TMUX_PANE` 取得 + 状態ファイル書込。
+   - pane 不明時は no-op。依存最小・高速。
+3. **状態ストア読込** (`src/actor/tmux_actor.rs`)
+   - refresh 時に状態ディレクトリを読み、`pane.id` にマッピング。
+   - `annotate_claude_panes` を拡張し `claude_state` をセット＋古いファイルの掃除。
+4. **データ構造拡張** (`src/app.rs`)
+   - `TmuxPane / TmuxWindow / TmuxSession` に `claude_state` を追加
+     （window/session は集約値）。
+5. **UI 描画** (`src/ui.rs`)
+   - `ClaudeState -> (記号, Color)` のマッピング関数を追加。
+   - 3 リストの描画を更新。既存の `CLAUDE_MARKER*` 定数を整理。
+6. **`hook install` 実装**
+   - 既存 settings.json を読み、`hooks` をマージして書き戻す
+     （既存設定を壊さない・冪等）。
+7. **テスト**
+   - JSON パース、状態集約、settings.json マージの単体テスト。
+   - `cargo test` / `cargo clippy`。
+8. **ドキュメント** (`README.md`)
+   - `tmux-deck hook install` のセットアップ手順とマーカーの意味を追記。
+   - README の `LLM Integration`（現状未チェック）を進捗反映。
+
+## 決定事項（このフェーズで確定）
+
+- 状態ファイル保存先: **`$XDG_STATE_HOME`**（未設定時 `~/.local/state`）。
+- hook 自動インストール先デフォルト: **ユーザーグローバル `~/.claude/settings.json`**。
+- 今フェーズのスコープ: **本計画ドキュメントの確定まで**。実装は次フェーズ。
+
+## 未確定・実装時に確定する事項
+
+- 採用する hook イベントの最終セット（`StopFailure` 等の存在確認）。
+- 各状態の最終的な記号・配色（点滅相当の表現可否含む）。
+- 状態ファイルのクリーンアップ間隔・保持時間の具体値。

--- a/docs/claude-hook-treeview-plan.md
+++ b/docs/claude-hook-treeview-plan.md
@@ -125,7 +125,7 @@ tmux-deck 本体
 
 | 状態 | 由来 | マーク | 色（案） |
 |---|---|---|---|
-| `Working` | `UserPromptSubmit` / `PreToolUse` | `●` | オレンジ (208) |
+| `Working` | `UserPromptSubmit` / `PreToolUse` | **dots スピナー（アニメーション）** | オレンジ (208) |
 | `Waiting` | `Notification`(permission/idle) | `◆` | 黄 |
 | `Idle` / `Done` | `Stop` (end_turn) | `●` | 緑 |
 | `Error` | （要確認）`StopFailure` 等 | `✗` | 赤 |
@@ -135,6 +135,45 @@ tmux-deck 本体
   フォールバックする。これにより hook 未設定環境でも従来どおり動作。
 - window / session への集約は注目度順
   （Waiting > Error > Working > Done > Unknown など）で最大値を採用。
+
+### Working マークのアニメーション（dots スピナー）
+
+`Working` 状態のマークは静的な記号ではなく、フレームが遷移して
+「回転して動いて見える」 braille の dots スピナーにする。
+
+- フレーム列（cli-spinners の `dots` 相当・10 フレーム）:
+
+  ```
+  ⠋ ⠙ ⠹ ⠸ ⠼ ⠴ ⠦ ⠧ ⠇ ⠏
+  ```
+
+- フレームの進め方は **時間ベース**にして、リフレッシュ間隔に依存せず
+  常に一定速度で回るようにする。描画時に現在時刻から算出:
+
+  ```text
+  frame_index = (now_millis / FRAME_INTERVAL_MS) % FRAMES.len()
+  // 例: FRAME_INTERVAL_MS = 80（≒12.5 fps）
+  ```
+
+  描画関数（`ui.rs`）にだけアニメーション状態を持たせ、状態ストアや
+  データ構造（`ClaudeState`）には**フレーム番号を持たせない**。
+  `ClaudeState::Working` であることだけを保持し、表示するフレームは
+  描画時刻から決定する（描画は純粋関数に近い形を保つ）。
+
+- 表示色は `Working` のオレンジ (208) を維持。色は固定、記号だけが遷移。
+
+#### アニメーションを成立させるための再描画
+
+スピナーが動いて見えるには、Working な Claude が存在する間、UI が
+継続的に再描画される必要がある。tmux-deck は `RefreshActor` の tick
+（`src/actor/refresh_actor.rs`）で再描画している。
+
+- どこかの pane が `Working` の間は、スピナーがなめらかに回る程度の
+  間隔（例: 100〜120ms）で再描画ティックを出すよう、リフレッシュ
+  cadence を見直す。
+- Working な対象が無いときは従来どおりの低頻度に戻し、無駄な再描画と
+  CPU 使用を避ける（アニメーション中だけ高頻度化する）。
+- 具体的なフレーム間隔・ティック間隔は実装時に体感で調整する。
 
 ## 実装ステップ（次フェーズ）
 
@@ -174,4 +213,5 @@ tmux-deck 本体
 
 - 採用する hook イベントの最終セット（`StopFailure` 等の存在確認）。
 - 各状態の最終的な記号・配色（点滅相当の表現可否含む）。
+- Working スピナーのフレーム間隔と、アニメーション中の再描画ティック間隔の具体値。
 - 状態ファイルのクリーンアップ間隔・保持時間の具体値。

--- a/src/actor/tmux_actor.rs
+++ b/src/actor/tmux_actor.rs
@@ -171,7 +171,7 @@ impl TmuxActor {
         let s_args: &[&str] = &[
             "list-sessions",
             "-F",
-            "SESS\t#{session_name}\t#{session_attached}\t#{session_activity}\t#{session_last_attached}",
+            "SESS\t#{session_name}\t#{session_activity}\t#{session_last_attached}",
         ];
         let w_args: &[&str] = &[
             "list-windows",
@@ -183,7 +183,7 @@ impl TmuxActor {
             "list-panes",
             "-a",
             "-F",
-            "PANE\t#{session_name}\t#{window_index}\t#{pane_id}\t#{pane_index}\t#{pane_width}\t#{pane_height}\t#{pane_active}\t#{pane_last}\t#{pane_current_command}",
+            "PANE\t#{session_name}\t#{window_index}\t#{pane_id}\t#{pane_index}\t#{pane_width}\t#{pane_height}\t#{pane_active}\t#{pane_last}\t#{pane_current_command}\t#{pane_pid}",
         ];
 
         // If control mode is up, send 3 commands as 3 blocks; otherwise one
@@ -219,6 +219,7 @@ impl TmuxActor {
         };
 
         let mut sessions = build_sessions(&stdout);
+        annotate_claude_panes(&mut sessions).await;
         crate::hook::apply_states(&mut sessions);
         TmuxResponse::SessionsRefreshed { sessions }
     }
@@ -675,7 +676,6 @@ fn quote_for_control(arg: &str) -> String {
 struct SessionAccum {
     activity: i64,
     last_attached: i64,
-    attached: bool,
     windows: Vec<WindowAccum>,
 }
 
@@ -704,7 +704,6 @@ fn build_sessions(stdout: &str) -> Vec<TmuxSession> {
         match tag {
             "SESS" => {
                 let name = it.next().unwrap_or("").to_string();
-                let attached = it.next() == Some("1");
                 let activity = it.next().and_then(|s| s.parse().ok()).unwrap_or(0);
                 let last_attached = it.next().and_then(|s| s.parse().ok()).unwrap_or(0);
                 if name.is_empty() {
@@ -718,7 +717,6 @@ fn build_sessions(stdout: &str) -> Vec<TmuxSession> {
                     SessionAccum {
                         activity,
                         last_attached,
-                        attached,
                         windows: Vec::new(),
                     },
                 );
@@ -749,6 +747,7 @@ fn build_sessions(stdout: &str) -> Vec<TmuxSession> {
                 let active = it.next() == Some("1");
                 let last = it.next() == Some("1");
                 let current_command = it.next().unwrap_or("").to_string();
+                let pid: u32 = it.next().and_then(|s| s.parse().ok()).unwrap_or(0);
 
                 if let Some(s) = sessions.get_mut(session)
                     && let Some(w) = s.windows.iter_mut().find(|w| w.index == window_index)
@@ -764,6 +763,8 @@ fn build_sessions(stdout: &str) -> Vec<TmuxSession> {
                             height,
                             active,
                             current_command,
+                            pid,
+                            has_claude: false,
                             claude_state: None,
                         },
                     ));
@@ -810,23 +811,123 @@ fn build_sessions(stdout: &str) -> Vec<TmuxSession> {
                 .map(|w| TmuxWindow {
                     index: w.index,
                     name: w.name,
-                    active: w.active,
                     panes: w.panes_raw.into_iter().map(|(_, _, _, p)| p).collect(),
+                    has_claude: false,
                     claude_state: None,
                 })
                 .collect();
-            let unread = !s.attached && s.activity > s.last_attached;
             Some(TmuxSession {
                 name,
-                attached: s.attached,
-                unread,
                 windows,
+                has_claude: false,
                 claude_state: None,
                 last_attached: s.last_attached,
                 activity: s.activity,
             })
         })
         .collect()
+}
+
+// =============================================================================
+// Claude-process detection
+// =============================================================================
+//
+// For each pane we already know the shell pid. A claude process running in
+// that pane shows up as a descendant — `claude` (or `.claude-wrapped`) under
+// the shell. We snapshot the full process table once per refresh and mark
+// any pane whose descendant tree contains such a process. The chrome native
+// host instance is excluded so it does not light up unrelated panes.
+
+async fn annotate_claude_panes(sessions: &mut [TmuxSession]) {
+    use std::collections::{HashMap, HashSet};
+
+    let output = match Command::new("ps")
+        .args(["-eo", "pid=,ppid=,args="])
+        .output()
+        .await
+    {
+        Ok(o) if o.status.success() => o,
+        _ => return,
+    };
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    let mut children: HashMap<u32, Vec<u32>> = HashMap::new();
+    let mut claude_pids: HashSet<u32> = HashSet::new();
+
+    for line in stdout.lines() {
+        let mut it = line.split_whitespace();
+        let pid: u32 = match it.next().and_then(|s| s.parse().ok()) {
+            Some(p) => p,
+            None => continue,
+        };
+        let ppid: u32 = match it.next().and_then(|s| s.parse().ok()) {
+            Some(p) => p,
+            None => continue,
+        };
+        let args: String = it.collect::<Vec<_>>().join(" ");
+
+        children.entry(ppid).or_default().push(pid);
+        if is_claude_args(&args) {
+            claude_pids.insert(pid);
+        }
+    }
+
+    if claude_pids.is_empty() {
+        return;
+    }
+
+    for session in sessions.iter_mut() {
+        let mut session_has = false;
+        for window in session.windows.iter_mut() {
+            let mut window_has = false;
+            for pane in window.panes.iter_mut() {
+                if pane.pid != 0 && pane_has_claude(pane.pid, &children, &claude_pids) {
+                    pane.has_claude = true;
+                    window_has = true;
+                }
+            }
+            window.has_claude = window_has;
+            if window_has {
+                session_has = true;
+            }
+        }
+        session.has_claude = session_has;
+    }
+}
+
+fn is_claude_args(args: &str) -> bool {
+    if args.is_empty() {
+        return false;
+    }
+    // The chrome-native-host instance is a separate, persistent helper that
+    // is not associated with an interactive pane.
+    if args.contains("--chrome-native-host") {
+        return false;
+    }
+    args.contains(".claude-wrapped")
+        || args.contains("claude-code/cli")
+        || args.split_whitespace().next() == Some("claude")
+}
+
+fn pane_has_claude(
+    root: u32,
+    children: &std::collections::HashMap<u32, Vec<u32>>,
+    claude_pids: &std::collections::HashSet<u32>,
+) -> bool {
+    let mut stack = vec![root];
+    let mut visited = std::collections::HashSet::new();
+    while let Some(pid) = stack.pop() {
+        if !visited.insert(pid) {
+            continue;
+        }
+        if claude_pids.contains(&pid) {
+            return true;
+        }
+        if let Some(kids) = children.get(&pid) {
+            stack.extend(kids.iter().copied());
+        }
+    }
+    false
 }
 
 fn append_switch_log(path: &str, target: &str, success: bool, error: Option<&str>) {

--- a/src/actor/tmux_actor.rs
+++ b/src/actor/tmux_actor.rs
@@ -183,7 +183,7 @@ impl TmuxActor {
             "list-panes",
             "-a",
             "-F",
-            "PANE\t#{session_name}\t#{window_index}\t#{pane_id}\t#{pane_index}\t#{pane_width}\t#{pane_height}\t#{pane_active}\t#{pane_last}\t#{pane_current_command}\t#{pane_pid}",
+            "PANE\t#{session_name}\t#{window_index}\t#{pane_id}\t#{pane_index}\t#{pane_width}\t#{pane_height}\t#{pane_active}\t#{pane_last}\t#{pane_current_command}",
         ];
 
         // If control mode is up, send 3 commands as 3 blocks; otherwise one
@@ -219,7 +219,6 @@ impl TmuxActor {
         };
 
         let mut sessions = build_sessions(&stdout);
-        annotate_claude_panes(&mut sessions).await;
         crate::hook::apply_states(&mut sessions);
         TmuxResponse::SessionsRefreshed { sessions }
     }
@@ -750,7 +749,6 @@ fn build_sessions(stdout: &str) -> Vec<TmuxSession> {
                 let active = it.next() == Some("1");
                 let last = it.next() == Some("1");
                 let current_command = it.next().unwrap_or("").to_string();
-                let pid: u32 = it.next().and_then(|s| s.parse().ok()).unwrap_or(0);
 
                 if let Some(s) = sessions.get_mut(session)
                     && let Some(w) = s.windows.iter_mut().find(|w| w.index == window_index)
@@ -766,8 +764,6 @@ fn build_sessions(stdout: &str) -> Vec<TmuxSession> {
                             height,
                             active,
                             current_command,
-                            pid,
-                            has_claude: false,
                             claude_state: None,
                         },
                     ));
@@ -816,7 +812,6 @@ fn build_sessions(stdout: &str) -> Vec<TmuxSession> {
                     name: w.name,
                     active: w.active,
                     panes: w.panes_raw.into_iter().map(|(_, _, _, p)| p).collect(),
-                    has_claude: false,
                     claude_state: None,
                 })
                 .collect();
@@ -826,115 +821,12 @@ fn build_sessions(stdout: &str) -> Vec<TmuxSession> {
                 attached: s.attached,
                 unread,
                 windows,
-                has_claude: false,
                 claude_state: None,
                 last_attached: s.last_attached,
                 activity: s.activity,
             })
         })
         .collect()
-}
-
-// =============================================================================
-// Claude-process detection
-// =============================================================================
-//
-// For each pane we already know the shell pid. A claude process running in
-// that pane shows up as a descendant — `claude` (or `.claude-wrapped`) under
-// the shell. We snapshot the full process table once per refresh and mark
-// any pane whose descendant tree contains such a process. The chrome native
-// host instance is excluded so it does not light up unrelated panes.
-
-async fn annotate_claude_panes(sessions: &mut [TmuxSession]) {
-    use std::collections::{HashMap, HashSet};
-
-    let output = match Command::new("ps")
-        .args(["-eo", "pid=,ppid=,args="])
-        .output()
-        .await
-    {
-        Ok(o) if o.status.success() => o,
-        _ => return,
-    };
-    let stdout = String::from_utf8_lossy(&output.stdout);
-
-    let mut children: HashMap<u32, Vec<u32>> = HashMap::new();
-    let mut claude_pids: HashSet<u32> = HashSet::new();
-
-    for line in stdout.lines() {
-        let mut it = line.split_whitespace();
-        let pid: u32 = match it.next().and_then(|s| s.parse().ok()) {
-            Some(p) => p,
-            None => continue,
-        };
-        let ppid: u32 = match it.next().and_then(|s| s.parse().ok()) {
-            Some(p) => p,
-            None => continue,
-        };
-        let args: String = it.collect::<Vec<_>>().join(" ");
-
-        children.entry(ppid).or_default().push(pid);
-        if is_claude_args(&args) {
-            claude_pids.insert(pid);
-        }
-    }
-
-    if claude_pids.is_empty() {
-        return;
-    }
-
-    for session in sessions.iter_mut() {
-        let mut session_has = false;
-        for window in session.windows.iter_mut() {
-            let mut window_has = false;
-            for pane in window.panes.iter_mut() {
-                if pane.pid != 0 && pane_has_claude(pane.pid, &children, &claude_pids) {
-                    pane.has_claude = true;
-                    window_has = true;
-                }
-            }
-            window.has_claude = window_has;
-            if window_has {
-                session_has = true;
-            }
-        }
-        session.has_claude = session_has;
-    }
-}
-
-fn is_claude_args(args: &str) -> bool {
-    if args.is_empty() {
-        return false;
-    }
-    // The chrome-native-host instance is a separate, persistent helper that
-    // is not associated with an interactive pane.
-    if args.contains("--chrome-native-host") {
-        return false;
-    }
-    args.contains(".claude-wrapped")
-        || args.contains("claude-code/cli")
-        || args.split_whitespace().next() == Some("claude")
-}
-
-fn pane_has_claude(
-    root: u32,
-    children: &std::collections::HashMap<u32, Vec<u32>>,
-    claude_pids: &std::collections::HashSet<u32>,
-) -> bool {
-    let mut stack = vec![root];
-    let mut visited = std::collections::HashSet::new();
-    while let Some(pid) = stack.pop() {
-        if !visited.insert(pid) {
-            continue;
-        }
-        if claude_pids.contains(&pid) {
-            return true;
-        }
-        if let Some(kids) = children.get(&pid) {
-            stack.extend(kids.iter().copied());
-        }
-    }
-    false
 }
 
 fn append_switch_log(path: &str, target: &str, success: bool, error: Option<&str>) {

--- a/src/actor/tmux_actor.rs
+++ b/src/actor/tmux_actor.rs
@@ -220,6 +220,7 @@ impl TmuxActor {
 
         let mut sessions = build_sessions(&stdout);
         annotate_claude_panes(&mut sessions).await;
+        crate::hook::apply_states(&mut sessions);
         TmuxResponse::SessionsRefreshed { sessions }
     }
 
@@ -767,6 +768,7 @@ fn build_sessions(stdout: &str) -> Vec<TmuxSession> {
                             current_command,
                             pid,
                             has_claude: false,
+                            claude_state: None,
                         },
                     ));
                 }
@@ -815,6 +817,7 @@ fn build_sessions(stdout: &str) -> Vec<TmuxSession> {
                     active: w.active,
                     panes: w.panes_raw.into_iter().map(|(_, _, _, p)| p).collect(),
                     has_claude: false,
+                    claude_state: None,
                 })
                 .collect();
             let unread = !s.attached && s.activity > s.last_attached;
@@ -824,6 +827,7 @@ fn build_sessions(stdout: &str) -> Vec<TmuxSession> {
                 unread,
                 windows,
                 has_claude: false,
+                claude_state: None,
                 last_attached: s.last_attached,
                 activity: s.activity,
             })

--- a/src/actor/ui_actor.rs
+++ b/src/actor/ui_actor.rs
@@ -82,7 +82,15 @@ impl UIActor {
             render_ui(frame, &mut self.state);
         })?;
 
+        // Drives the Claude "Working" dots spinner. Ticks frequently, but only
+        // forces a redraw while something is actually animating, so an idle TUI
+        // stays event-driven.
+        let mut anim = tokio::time::interval(Duration::from_millis(80));
+
         loop {
+            // Default to redrawing; the animation tick decides for itself.
+            let mut redraw = true;
+
             // Use select to handle multiple event sources
             // biased; ensures key events are checked first (top-to-bottom priority)
             tokio::select! {
@@ -104,6 +112,11 @@ impl UIActor {
                 Some(event) = self.ui_event_rx.recv() => {
                     match event {
                         UIEvent::Tick => {
+                            // Cheap, local: fold the latest Claude hook states
+                            // into the tree so markers stay live between full
+                            // tmux refreshes.
+                            self.state.refresh_claude_states();
+
                             // Request pane capture if in TreeView mode (low-priority channel)
                             if self.state.view_mode == ViewMode::TreeView
                                 && let Some((target, start, end)) =
@@ -121,12 +134,19 @@ impl UIActor {
                         _ => (),
                     }
                 }
+
+                // Spinner animation tick: only redraw if a spinner is active.
+                _ = anim.tick() => {
+                    redraw = self.state.has_working_claude();
+                }
             }
 
             // Render UI after processing event (event-driven rendering)
-            self.terminal.draw(|frame| {
-                render_ui(frame, &mut self.state);
-            })?;
+            if redraw {
+                self.terminal.draw(|frame| {
+                    render_ui(frame, &mut self.state);
+                })?;
+            }
         }
 
         Ok(())

--- a/src/app.rs
+++ b/src/app.rs
@@ -10,8 +10,9 @@ use ratatui::widgets::ListState;
 
 /// State reported by Claude Code hooks for a given pane.
 ///
-/// Sourced from Claude Code's hook events (see [`crate::hook`]), these tell us
-/// *what claude is doing* in a pane. Variants are ordered loosely by how much
+/// Process detection (`has_claude`) only tells us whether claude is running;
+/// these states tell us *what claude is doing*, sourced from Claude Code's
+/// hook events (see [`crate::hook`]). Variants are ordered loosely by how much
 /// they want the user's attention — see [`ClaudeState::priority`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ClaudeState {
@@ -95,6 +96,9 @@ pub struct TmuxPane {
     pub height: u32,
     pub active: bool,
     pub current_command: String,
+    pub pid: u32,
+    /// True if a claude process is running in this pane (detected via descendant process scan).
+    pub has_claude: bool,
     /// Latest state reported by Claude Code hooks for this pane, if any.
     pub claude_state: Option<ClaudeState>,
 }
@@ -104,8 +108,9 @@ pub struct TmuxPane {
 pub struct TmuxWindow {
     pub index: u32,
     pub name: String,
-    pub active: bool,
     pub panes: Vec<TmuxPane>,
+    /// True if any pane in this window has claude running.
+    pub has_claude: bool,
     /// Highest-priority Claude hook state across this window's panes.
     pub claude_state: Option<ClaudeState>,
 }
@@ -120,12 +125,9 @@ impl TmuxWindow {
 #[derive(Debug, Clone)]
 pub struct TmuxSession {
     pub name: String,
-    pub attached: bool,
-    /// True if the session has activity newer than its last_attached and
-    /// is not currently attached — i.e. something happened in there that
-    /// the user has not seen yet.
-    pub unread: bool,
     pub windows: Vec<TmuxWindow>,
+    /// True if any window in this session has claude running.
+    pub has_claude: bool,
     /// Highest-priority Claude hook state across this session's windows.
     pub claude_state: Option<ClaudeState>,
     /// Epoch seconds — kept on the struct so [`SessionSort`] can reorder

--- a/src/app.rs
+++ b/src/app.rs
@@ -10,9 +10,8 @@ use ratatui::widgets::ListState;
 
 /// State reported by Claude Code hooks for a given pane.
 ///
-/// Process detection (`has_claude`) only tells us whether claude is running;
-/// these states tell us *what claude is doing*, sourced from Claude Code's
-/// hook events (see [`crate::hook`]). Variants are ordered loosely by how much
+/// Sourced from Claude Code's hook events (see [`crate::hook`]), these tell us
+/// *what claude is doing* in a pane. Variants are ordered loosely by how much
 /// they want the user's attention — see [`ClaudeState::priority`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ClaudeState {
@@ -96,9 +95,6 @@ pub struct TmuxPane {
     pub height: u32,
     pub active: bool,
     pub current_command: String,
-    pub pid: u32,
-    /// True if a claude process is running in this pane (detected via descendant process scan).
-    pub has_claude: bool,
     /// Latest state reported by Claude Code hooks for this pane, if any.
     pub claude_state: Option<ClaudeState>,
 }
@@ -110,8 +106,6 @@ pub struct TmuxWindow {
     pub name: String,
     pub active: bool,
     pub panes: Vec<TmuxPane>,
-    /// True if any pane in this window has claude running.
-    pub has_claude: bool,
     /// Highest-priority Claude hook state across this window's panes.
     pub claude_state: Option<ClaudeState>,
 }
@@ -132,8 +126,6 @@ pub struct TmuxSession {
     /// the user has not seen yet.
     pub unread: bool,
     pub windows: Vec<TmuxWindow>,
-    /// True if any window in this session has claude running.
-    pub has_claude: bool,
     /// Highest-priority Claude hook state across this session's windows.
     pub claude_state: Option<ClaudeState>,
     /// Epoch seconds — kept on the struct so [`SessionSort`] can reorder

--- a/src/app.rs
+++ b/src/app.rs
@@ -8,6 +8,83 @@ use ratatui::widgets::ListState;
 // Data Structures
 // =============================================================================
 
+/// State reported by Claude Code hooks for a given pane.
+///
+/// Process detection (`has_claude`) only tells us whether claude is running;
+/// these states tell us *what claude is doing*, sourced from Claude Code's
+/// hook events (see [`crate::hook`]). Variants are ordered loosely by how much
+/// they want the user's attention — see [`ClaudeState::priority`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClaudeState {
+    /// Claude is actively working (prompt submitted / tool running).
+    Working,
+    /// Claude is waiting on the user (permission prompt / idle prompt).
+    Waiting,
+    /// Claude finished its turn.
+    Done,
+    /// Claude's turn ended with an error.
+    Error,
+}
+
+impl ClaudeState {
+    /// Map a Claude Code `hook_event_name` to the state it implies.
+    /// Returns `None` for events that carry no marker meaning (the caller may
+    /// treat `SessionEnd` specially, clearing any existing marker).
+    pub fn from_hook_event(event: &str) -> Option<Self> {
+        match event {
+            "UserPromptSubmit" | "PreToolUse" | "PostToolUse" | "PreCompact" => Some(Self::Working),
+            "Notification" => Some(Self::Waiting),
+            "Stop" | "SubagentStop" => Some(Self::Done),
+            // StopFailure is not yet confirmed in the public docs; map it
+            // defensively so it lights up red if it ever fires.
+            "StopFailure" => Some(Self::Error),
+            _ => None,
+        }
+    }
+
+    /// Stable lowercase token used in the on-disk state files.
+    pub fn as_token(self) -> &'static str {
+        match self {
+            Self::Working => "working",
+            Self::Waiting => "waiting",
+            Self::Done => "done",
+            Self::Error => "error",
+        }
+    }
+
+    /// Inverse of [`Self::as_token`].
+    pub fn from_token(token: &str) -> Option<Self> {
+        match token {
+            "working" => Some(Self::Working),
+            "waiting" => Some(Self::Waiting),
+            "done" => Some(Self::Done),
+            "error" => Some(Self::Error),
+            _ => None,
+        }
+    }
+
+    /// How strongly this state wants the user's attention. Used when rolling
+    /// pane states up into a single window / session marker — the highest
+    /// priority among children wins.
+    pub fn priority(self) -> u8 {
+        match self {
+            Self::Waiting => 3,
+            Self::Error => 2,
+            Self::Working => 1,
+            Self::Done => 0,
+        }
+    }
+
+    /// Combine two optional states, keeping the higher-priority one.
+    pub fn merge(a: Option<Self>, b: Option<Self>) -> Option<Self> {
+        match (a, b) {
+            (Some(x), Some(y)) => Some(if x.priority() >= y.priority() { x } else { y }),
+            (Some(x), None) => Some(x),
+            (None, b) => b,
+        }
+    }
+}
+
 /// Represents a tmux pane
 #[derive(Debug, Clone)]
 pub struct TmuxPane {
@@ -22,6 +99,8 @@ pub struct TmuxPane {
     pub pid: u32,
     /// True if a claude process is running in this pane (detected via descendant process scan).
     pub has_claude: bool,
+    /// Latest state reported by Claude Code hooks for this pane, if any.
+    pub claude_state: Option<ClaudeState>,
 }
 
 /// Represents a tmux window with captured content
@@ -33,6 +112,8 @@ pub struct TmuxWindow {
     pub panes: Vec<TmuxPane>,
     /// True if any pane in this window has claude running.
     pub has_claude: bool,
+    /// Highest-priority Claude hook state across this window's panes.
+    pub claude_state: Option<ClaudeState>,
 }
 
 impl TmuxWindow {
@@ -53,6 +134,8 @@ pub struct TmuxSession {
     pub windows: Vec<TmuxWindow>,
     /// True if any window in this session has claude running.
     pub has_claude: bool,
+    /// Highest-priority Claude hook state across this session's windows.
+    pub claude_state: Option<ClaudeState>,
     /// Epoch seconds — kept on the struct so [`SessionSort`] can reorder
     /// the list without re-querying tmux.
     pub last_attached: i64,
@@ -302,6 +385,22 @@ impl UIState {
     // =========================================================================
     // View Mode Switching
     // =========================================================================
+
+    /// Re-read Claude hook state files and patch the in-memory session tree.
+    ///
+    /// Cheap enough to call on every refresh tick: it only reads a small local
+    /// state directory. This keeps markers live without a full tmux refresh.
+    pub fn refresh_claude_states(&mut self) {
+        crate::hook::apply_states(&mut self.sessions);
+    }
+
+    /// True if any session currently has a `Working` Claude marker, used to
+    /// decide whether the spinner animation needs frequent redraws.
+    pub fn has_working_claude(&self) -> bool {
+        self.sessions
+            .iter()
+            .any(|s| s.claude_state == Some(ClaudeState::Working))
+    }
 
     pub fn handle_space_press(&mut self) -> bool {
         let now = Instant::now();

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,5 @@
 use clap::{
-    CommandFactory, FromArgMatches, Parser,
+    CommandFactory, FromArgMatches, Parser, Subcommand,
     builder::{Styles, styling::AnsiColor},
 };
 use color_eyre::Result;
@@ -17,6 +17,35 @@ pub struct Cli {
     /// Preview refresh interval in milliseconds
     #[arg(short, long, default_value = "300")]
     pub interval: u64,
+    /// Subcommand (omit to launch the interactive TUI)
+    #[command(subcommand)]
+    pub command: Option<Command>,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum Command {
+    /// Claude Code hook integration: drive treeview markers from Claude's state.
+    Hook {
+        #[command(subcommand)]
+        action: HookAction,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum HookAction {
+    /// Report a Claude hook event (reads the hook JSON on stdin).
+    ///
+    /// This is meant to be wired into Claude Code's `settings.json` as a
+    /// `command` hook. It records the calling pane's Claude state so the
+    /// tmux-deck TUI can render a per-pane marker.
+    Report,
+    /// Install the tmux-deck hooks into Claude Code's settings.json.
+    Install {
+        /// Install into the project-local `.claude/settings.json` instead of
+        /// the user-global `~/.claude/settings.json`.
+        #[arg(long)]
+        project: bool,
+    },
 }
 
 impl Cli {

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -1,0 +1,400 @@
+//! Claude Code hook integration.
+//!
+//! Two halves live here:
+//!
+//! * The **reporter** (`tmux-deck hook report`) is wired into Claude Code's
+//!   `settings.json`. Claude runs it on each hook event, passing the hook JSON
+//!   on stdin. It records the *calling pane's* Claude state to a small file
+//!   keyed by `$TMUX_PANE`.
+//! * The **reader** ([`apply_states`]) is used by the TUI to fold those files
+//!   back into the session tree so each pane/window/session can show a marker
+//!   reflecting what Claude is doing.
+//!
+//! The two sides are linked purely by `$TMUX_PANE`: the reporter inherits it
+//! from the pane Claude runs in, and tmux exposes the same id as `#{pane_id}`.
+
+use std::collections::HashMap;
+use std::io::Read;
+use std::path::PathBuf;
+
+use directories::ProjectDirs;
+use serde_json::{Value, json};
+
+use crate::app::{ClaudeState, TmuxSession};
+
+/// Hook events we install and listen for. `SessionEnd` is included so a pane's
+/// marker is cleared when Claude exits.
+const MANAGED_EVENTS: &[&str] = &[
+    "UserPromptSubmit",
+    "PreToolUse",
+    "PostToolUse",
+    "Notification",
+    "Stop",
+    "SubagentStop",
+    "SessionEnd",
+];
+
+/// Drop state files older than this. A pane that closes without firing
+/// `SessionEnd` (e.g. killed) would otherwise leave a stale marker forever.
+const STALE_SECS: i64 = 6 * 60 * 60;
+
+/// Substring that identifies a hook command as ours, for idempotent install.
+const COMMAND_MARKER: &str = "hook report";
+
+// =============================================================================
+// Paths / time helpers
+// =============================================================================
+
+/// Directory holding per-pane Claude state files.
+///
+/// Resolves to `$XDG_STATE_HOME/tmux-deck/claude` (the `directories` crate
+/// honours `XDG_STATE_HOME` on Linux), falling back to `~/.local/state/...`
+/// on platforms where a state dir is not otherwise defined.
+fn state_dir() -> Option<PathBuf> {
+    let base = ProjectDirs::from("dev", "tkcd", "tmux-deck")
+        .and_then(|p| p.state_dir().map(|s| s.to_path_buf()))
+        .or_else(|| {
+            std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".local/state/tmux-deck"))
+        })?;
+    Some(base.join("claude"))
+}
+
+fn now_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+/// Make a filesystem-safe file stem from a tmux pane id like `%3`.
+fn pane_file_stem(pane: &str) -> String {
+    let stem: String = pane
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect();
+    stem
+}
+
+// =============================================================================
+// Reporter: `tmux-deck hook report`
+// =============================================================================
+
+/// Entry point for `tmux-deck hook report`.
+///
+/// Always exits quietly (the caller — Claude — should never be disrupted by a
+/// hook), so every failure path is a silent early return.
+pub fn run_report() {
+    let mut input = String::new();
+    let _ = std::io::stdin().read_to_string(&mut input);
+
+    // Without a pane id we cannot attribute the event to anything.
+    let pane = match std::env::var("TMUX_PANE") {
+        Ok(p) if !p.is_empty() => p,
+        _ => return,
+    };
+
+    let event = serde_json::from_str::<Value>(&input)
+        .ok()
+        .and_then(|v| {
+            v.get("hook_event_name")
+                .and_then(|e| e.as_str())
+                .map(String::from)
+        });
+    let event = match event {
+        Some(e) => e,
+        None => return,
+    };
+
+    let dir = match state_dir() {
+        Some(d) => d,
+        None => return,
+    };
+    let _ = std::fs::create_dir_all(&dir);
+    let file = dir.join(format!("{}.json", pane_file_stem(&pane)));
+
+    match ClaudeState::from_hook_event(&event) {
+        Some(state) => {
+            let record = json!({
+                "pane": pane,
+                "state": state.as_token(),
+                "event": event,
+                "ts": now_secs(),
+            });
+            let _ = std::fs::write(&file, record.to_string());
+        }
+        None => {
+            // SessionEnd (and any other terminal/unmapped event) clears the
+            // marker so a finished pane stops showing a stale state.
+            if event == "SessionEnd" {
+                let _ = std::fs::remove_file(&file);
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Reader: fold state files into the session tree
+// =============================================================================
+
+/// Load the current per-pane states, keyed by tmux pane id (`%N`).
+/// Stale files are removed as a side effect.
+fn load_states() -> HashMap<String, ClaudeState> {
+    let mut map = HashMap::new();
+    let dir = match state_dir() {
+        Some(d) => d,
+        None => return map,
+    };
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(e) => e,
+        Err(_) => return map,
+    };
+    let now = now_secs();
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let content = match std::fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        let value: Value = match serde_json::from_str(&content) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+
+        let ts = value.get("ts").and_then(|t| t.as_i64()).unwrap_or(0);
+        if now - ts > STALE_SECS {
+            let _ = std::fs::remove_file(&path);
+            continue;
+        }
+        let pane = match value.get("pane").and_then(|p| p.as_str()) {
+            Some(p) => p.to_string(),
+            None => continue,
+        };
+        let state = match value
+            .get("state")
+            .and_then(|s| s.as_str())
+            .and_then(ClaudeState::from_token)
+        {
+            Some(s) => s,
+            None => continue,
+        };
+        map.insert(pane, state);
+    }
+    map
+}
+
+/// Apply the current hook states to a session tree, recomputing the
+/// per-pane / per-window / per-session markers. Always recomputes from the
+/// files on disk, so a marker that has gone away is cleared too.
+pub fn apply_states(sessions: &mut [TmuxSession]) {
+    let map = load_states();
+    for session in sessions.iter_mut() {
+        let mut session_state = None;
+        for window in session.windows.iter_mut() {
+            let mut window_state = None;
+            for pane in window.panes.iter_mut() {
+                pane.claude_state = map.get(&pane.id).copied();
+                window_state = ClaudeState::merge(window_state, pane.claude_state);
+            }
+            window.claude_state = window_state;
+            session_state = ClaudeState::merge(session_state, window_state);
+        }
+        session.claude_state = session_state;
+    }
+}
+
+// =============================================================================
+// Installer: `tmux-deck hook install`
+// =============================================================================
+
+/// Entry point for `tmux-deck hook install [--project]`.
+pub fn run_install(project: bool) -> color_eyre::Result<()> {
+    let path = settings_path(project)?;
+    let command = report_command();
+
+    let existing = match std::fs::read_to_string(&path) {
+        Ok(s) if !s.trim().is_empty() => serde_json::from_str::<Value>(&s)?,
+        _ => json!({}),
+    };
+    let merged = merge_hooks(existing, &command);
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut out = serde_json::to_string_pretty(&merged)?;
+    out.push('\n');
+    std::fs::write(&path, out)?;
+
+    println!("Installed tmux-deck Claude hooks into {}", path.display());
+    println!("Events: {}", MANAGED_EVENTS.join(", "));
+    Ok(())
+}
+
+/// The command Claude should run for each event. Uses the absolute path to the
+/// current executable so it works regardless of `$PATH`.
+fn report_command() -> String {
+    let exe = std::env::current_exe()
+        .ok()
+        .and_then(|p| p.to_str().map(String::from))
+        .unwrap_or_else(|| "tmux-deck".to_string());
+    format!("{} hook report", exe)
+}
+
+fn settings_path(project: bool) -> color_eyre::Result<PathBuf> {
+    if project {
+        Ok(PathBuf::from(".claude").join("settings.json"))
+    } else {
+        let home = std::env::var_os("HOME")
+            .map(PathBuf::from)
+            .ok_or_else(|| color_eyre::eyre::eyre!("HOME is not set"))?;
+        Ok(home.join(".claude").join("settings.json"))
+    }
+}
+
+/// Merge our managed hooks into an existing settings document, idempotently.
+///
+/// Any previously-installed tmux-deck report hook is removed first, so running
+/// install repeatedly never duplicates entries and always refreshes the path.
+fn merge_hooks(mut root: Value, command: &str) -> Value {
+    if !root.is_object() {
+        root = json!({});
+    }
+    let obj = root.as_object_mut().expect("root is an object");
+
+    let hooks = obj.entry("hooks").or_insert_with(|| json!({}));
+    if !hooks.is_object() {
+        *hooks = json!({});
+    }
+    let hooks = hooks.as_object_mut().expect("hooks is an object");
+
+    for event in MANAGED_EVENTS {
+        let entry = hooks.entry((*event).to_string()).or_insert_with(|| json!([]));
+        if !entry.is_array() {
+            *entry = json!([]);
+        }
+        let groups = entry.as_array_mut().expect("event is an array");
+        groups.retain(|group| !group_is_ours(group));
+        groups.push(json!({
+            "hooks": [ { "type": "command", "command": command } ]
+        }));
+    }
+    root
+}
+
+/// Whether a hook group was installed by us (contains a `hook report` command).
+fn group_is_ours(group: &Value) -> bool {
+    group
+        .get("hooks")
+        .and_then(|h| h.as_array())
+        .map(|hooks| {
+            hooks.iter().any(|h| {
+                h.get("command")
+                    .and_then(|c| c.as_str())
+                    .map(|c| c.contains(COMMAND_MARKER))
+                    .unwrap_or(false)
+            })
+        })
+        .unwrap_or(false)
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_hook_events_to_states() {
+        assert_eq!(
+            ClaudeState::from_hook_event("UserPromptSubmit"),
+            Some(ClaudeState::Working)
+        );
+        assert_eq!(
+            ClaudeState::from_hook_event("Notification"),
+            Some(ClaudeState::Waiting)
+        );
+        assert_eq!(ClaudeState::from_hook_event("Stop"), Some(ClaudeState::Done));
+        assert_eq!(ClaudeState::from_hook_event("SessionEnd"), None);
+        assert_eq!(ClaudeState::from_hook_event("Whatever"), None);
+    }
+
+    #[test]
+    fn token_roundtrips() {
+        for s in [
+            ClaudeState::Working,
+            ClaudeState::Waiting,
+            ClaudeState::Done,
+            ClaudeState::Error,
+        ] {
+            assert_eq!(ClaudeState::from_token(s.as_token()), Some(s));
+        }
+    }
+
+    #[test]
+    fn merge_keeps_higher_priority() {
+        // Waiting (3) beats Working (1); Done (0) loses to everything.
+        assert_eq!(
+            ClaudeState::merge(Some(ClaudeState::Working), Some(ClaudeState::Waiting)),
+            Some(ClaudeState::Waiting)
+        );
+        assert_eq!(
+            ClaudeState::merge(Some(ClaudeState::Done), Some(ClaudeState::Working)),
+            Some(ClaudeState::Working)
+        );
+        assert_eq!(
+            ClaudeState::merge(None, Some(ClaudeState::Done)),
+            Some(ClaudeState::Done)
+        );
+        assert_eq!(ClaudeState::merge(None, None), None);
+    }
+
+    #[test]
+    fn pane_file_stem_is_safe() {
+        assert_eq!(pane_file_stem("%3"), "_3");
+        assert_eq!(pane_file_stem("%12"), "_12");
+    }
+
+    #[test]
+    fn merge_hooks_adds_all_events() {
+        let merged = merge_hooks(json!({}), "tmux-deck hook report");
+        let hooks = merged.get("hooks").unwrap().as_object().unwrap();
+        for event in MANAGED_EVENTS {
+            let groups = hooks.get(*event).unwrap().as_array().unwrap();
+            assert_eq!(groups.len(), 1, "event {event} should have one group");
+            assert!(group_is_ours(&groups[0]));
+        }
+    }
+
+    #[test]
+    fn merge_hooks_is_idempotent() {
+        let once = merge_hooks(json!({}), "tmux-deck hook report");
+        let twice = merge_hooks(once.clone(), "tmux-deck hook report");
+        assert_eq!(once, twice, "installing twice must not duplicate hooks");
+    }
+
+    #[test]
+    fn merge_hooks_preserves_foreign_entries() {
+        let existing = json!({
+            "hooks": {
+                "Stop": [
+                    { "hooks": [ { "type": "command", "command": "echo other" } ] }
+                ]
+            },
+            "permissions": { "allow": ["Bash"] }
+        });
+        let merged = merge_hooks(existing, "tmux-deck hook report");
+
+        // Foreign top-level keys survive.
+        assert!(merged.get("permissions").is_some());
+        // Foreign Stop hook is kept alongside ours.
+        let stop = merged["hooks"]["Stop"].as_array().unwrap();
+        assert_eq!(stop.len(), 2);
+        assert!(stop.iter().any(|g| !group_is_ours(g)));
+        assert!(stop.iter().any(group_is_ours));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod actor;
 mod app;
 mod cli;
+mod hook;
 mod ui;
 
 use std::io;
@@ -18,7 +19,7 @@ use tracing_subscriber::{EnvFilter, fmt::time};
 
 use actor::{RefreshActor, RefreshControl, TmuxActor, TmuxCommand, TmuxResponse, UIActor, UIEvent};
 use app::UIState;
-use cli::Cli;
+use cli::{Cli, Command, HookAction};
 
 // =============================================================================
 // Main
@@ -28,6 +29,20 @@ use cli::Cli;
 async fn main() -> Result<()> {
     color_eyre::install()?;
     let cmd = Cli::parse_with_color()?;
+
+    // Subcommands run without the TUI / terminal setup.
+    if let Some(command) = &cmd.command {
+        return match command {
+            Command::Hook { action } => match action {
+                HookAction::Report => {
+                    hook::run_report();
+                    Ok(())
+                }
+                HookAction::Install { project } => hook::run_install(*project),
+            },
+        };
+    }
+
     let project_dir =
         ProjectDirs::from("dev", "tkcd", "tmux-deck").expect("cannot determine project directory");
     let log_dir = project_dir.state_dir().expect("failed to get log dir");

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -5,11 +5,13 @@ use ratatui::{
 
 use crate::app::{ClaudeState, Focus, InputMode, PopupMode, TmuxPane, TmuxWindow, UIState, ViewMode};
 
-/// Orange color used to flag sessions / windows / panes that have a claude
-/// process running. Color::Indexed(208) is the standard 256-color "Orange1"
-/// slot, which renders consistently across terminals that do not honour
-/// truecolor.
+/// Single colour used for every Claude marker. States are distinguished by
+/// glyph *shape*, not colour, so the markers stay legible regardless of the
+/// terminal palette or colour-blindness. Color::Indexed(208) is the standard
+/// 256-color "Orange1" slot, which renders consistently across terminals that
+/// do not honour truecolor.
 const CLAUDE_MARKER_COLOR: Color = Color::Indexed(208);
+/// Marker shown for a claude process when no hook state is known.
 const CLAUDE_MARKER: &str = "●";
 
 /// Braille "dots" spinner frames (cli-spinners `dots`). Rendered for the
@@ -32,38 +34,31 @@ fn spinner_frame() -> &'static str {
     SPINNER_FRAMES[idx]
 }
 
-/// Color for a given Claude state.
-fn claude_color(state: ClaudeState) -> Color {
-    match state {
-        ClaudeState::Working => CLAUDE_MARKER_COLOR,
-        ClaudeState::Waiting => Color::Yellow,
-        ClaudeState::Done => Color::Green,
-        ClaudeState::Error => Color::Red,
-    }
-}
-
-/// The marker glyph + color to show for a node, given its hook state and
-/// whether a claude process was detected. Hook state wins; otherwise we fall
-/// back to the plain "claude is running" marker so behaviour is unchanged when
-/// hooks are not installed. Returns `None` when there is nothing to show.
+/// The marker glyph + colour to show for a node, given its hook state and
+/// whether a claude process was detected. States are distinguished by shape
+/// (the colour is always the same); hook state wins, otherwise we fall back to
+/// the plain "claude is running" dot so behaviour is unchanged when hooks are
+/// not installed. Returns `None` when there is nothing to show.
 fn claude_marker(state: Option<ClaudeState>, has_claude: bool) -> Option<(&'static str, Color)> {
-    match state {
-        Some(ClaudeState::Working) => Some((spinner_frame(), CLAUDE_MARKER_COLOR)),
-        Some(ClaudeState::Waiting) => Some(("◆", claude_color(ClaudeState::Waiting))),
-        Some(ClaudeState::Done) => Some(("●", claude_color(ClaudeState::Done))),
-        Some(ClaudeState::Error) => Some(("✗", claude_color(ClaudeState::Error))),
-        None if has_claude => Some((CLAUDE_MARKER, CLAUDE_MARKER_COLOR)),
-        None => None,
-    }
+    let sym = match state {
+        Some(ClaudeState::Working) => spinner_frame(),
+        Some(ClaudeState::Waiting) => "◆",
+        Some(ClaudeState::Done) => "✓",
+        Some(ClaudeState::Error) => "✗",
+        None if has_claude => CLAUDE_MARKER,
+        None => return None,
+    };
+    Some((sym, CLAUDE_MARKER_COLOR))
 }
 
-/// Border accent color for a node based on its Claude state, falling back to
-/// the plain claude color when only a process was detected.
+/// Border accent colour for a node that is running claude (any state). The
+/// border only signals presence — state is conveyed by the marker shape — so a
+/// single colour is used throughout.
 fn claude_border_color(state: Option<ClaudeState>, has_claude: bool) -> Option<Color> {
-    match state {
-        Some(s) => Some(claude_color(s)),
-        None if has_claude => Some(CLAUDE_MARKER_COLOR),
-        None => None,
+    if state.is_some() || has_claude {
+        Some(CLAUDE_MARKER_COLOR)
+    } else {
+        None
     }
 }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -3,7 +3,7 @@ use ratatui::{
     widgets::{Block, Borders, Clear, List, ListItem, Paragraph, Wrap},
 };
 
-use crate::app::{Focus, InputMode, PopupMode, TmuxPane, TmuxWindow, UIState, ViewMode};
+use crate::app::{ClaudeState, Focus, InputMode, PopupMode, TmuxPane, TmuxWindow, UIState, ViewMode};
 
 /// Orange color used to flag sessions / windows / panes that have a claude
 /// process running. Color::Indexed(208) is the standard 256-color "Orange1"
@@ -11,6 +11,61 @@ use crate::app::{Focus, InputMode, PopupMode, TmuxPane, TmuxWindow, UIState, Vie
 /// truecolor.
 const CLAUDE_MARKER_COLOR: Color = Color::Indexed(208);
 const CLAUDE_MARKER: &str = "●";
+
+/// Braille "dots" spinner frames (cli-spinners `dots`). Rendered for the
+/// `Working` Claude state so the marker visibly animates.
+const SPINNER_FRAMES: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+/// Milliseconds each spinner frame is shown.
+const SPINNER_FRAME_MS: u128 = 80;
+
+fn now_millis() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0)
+}
+
+/// The current spinner glyph, chosen from wall-clock time so it animates at a
+/// constant rate regardless of how often we happen to redraw.
+fn spinner_frame() -> &'static str {
+    let idx = (now_millis() / SPINNER_FRAME_MS) as usize % SPINNER_FRAMES.len();
+    SPINNER_FRAMES[idx]
+}
+
+/// Color for a given Claude state.
+fn claude_color(state: ClaudeState) -> Color {
+    match state {
+        ClaudeState::Working => CLAUDE_MARKER_COLOR,
+        ClaudeState::Waiting => Color::Yellow,
+        ClaudeState::Done => Color::Green,
+        ClaudeState::Error => Color::Red,
+    }
+}
+
+/// The marker glyph + color to show for a node, given its hook state and
+/// whether a claude process was detected. Hook state wins; otherwise we fall
+/// back to the plain "claude is running" marker so behaviour is unchanged when
+/// hooks are not installed. Returns `None` when there is nothing to show.
+fn claude_marker(state: Option<ClaudeState>, has_claude: bool) -> Option<(&'static str, Color)> {
+    match state {
+        Some(ClaudeState::Working) => Some((spinner_frame(), CLAUDE_MARKER_COLOR)),
+        Some(ClaudeState::Waiting) => Some(("◆", claude_color(ClaudeState::Waiting))),
+        Some(ClaudeState::Done) => Some(("●", claude_color(ClaudeState::Done))),
+        Some(ClaudeState::Error) => Some(("✗", claude_color(ClaudeState::Error))),
+        None if has_claude => Some((CLAUDE_MARKER, CLAUDE_MARKER_COLOR)),
+        None => None,
+    }
+}
+
+/// Border accent color for a node based on its Claude state, falling back to
+/// the plain claude color when only a process was detected.
+fn claude_border_color(state: Option<ClaudeState>, has_claude: bool) -> Option<Color> {
+    match state {
+        Some(s) => Some(claude_color(s)),
+        None if has_claude => Some(CLAUDE_MARKER_COLOR),
+        None => None,
+    }
+}
 
 // =============================================================================
 // Main UI Rendering
@@ -93,10 +148,10 @@ fn render_sessions_list(frame: &mut Frame, state: &mut UIState, area: Rect) {
             } else if session.unread {
                 spans.push(Span::styled(" ◆", Style::default().fg(Color::Yellow)));
             }
-            if session.has_claude {
+            if let Some((sym, color)) = claude_marker(session.claude_state, session.has_claude) {
                 spans.push(Span::styled(
-                    format!(" {}", CLAUDE_MARKER),
-                    Style::default().fg(CLAUDE_MARKER_COLOR),
+                    format!(" {}", sym),
+                    Style::default().fg(color),
                 ));
             }
             ListItem::new(Line::from(spans)).style(style)
@@ -149,10 +204,10 @@ fn render_windows_list(frame: &mut Frame, state: &mut UIState, area: Rect) {
                 "{}:{}{}",
                 window.index, window.name, active_marker
             ))];
-            if window.has_claude {
+            if let Some((sym, color)) = claude_marker(window.claude_state, window.has_claude) {
                 spans.push(Span::styled(
-                    format!(" {}", CLAUDE_MARKER),
-                    Style::default().fg(CLAUDE_MARKER_COLOR),
+                    format!(" {}", sym),
+                    Style::default().fg(color),
                 ));
             }
             ListItem::new(Line::from(spans)).style(style)
@@ -208,10 +263,10 @@ fn render_panes_list(frame: &mut Frame, state: &mut UIState, area: Rect) {
                 "{}:{}{} [{}]",
                 pane.index, pane.id, active_marker, pane.current_command
             ))];
-            if pane.has_claude {
+            if let Some((sym, color)) = claude_marker(pane.claude_state, pane.has_claude) {
                 spans.push(Span::styled(
-                    format!(" {}", CLAUDE_MARKER),
-                    Style::default().fg(CLAUDE_MARKER_COLOR),
+                    format!(" {}", sym),
+                    Style::default().fg(color),
                 ));
             }
             ListItem::new(Line::from(spans)).style(style)
@@ -356,8 +411,10 @@ fn render_multi_preview(frame: &mut Frame, state: &UIState) {
             // colour wins so the user does not lose track of focus).
             let session_border_style = if is_selected_session {
                 Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)
-            } else if session.has_claude {
-                Style::default().fg(CLAUDE_MARKER_COLOR)
+            } else if let Some(color) =
+                claude_border_color(session.claude_state, session.has_claude)
+            {
+                Style::default().fg(color)
             } else if session.attached {
                 Style::default().fg(Color::Green)
             } else {
@@ -370,10 +427,10 @@ fn render_multi_preview(frame: &mut Frame, state: &UIState) {
             } else if session.unread {
                 title_spans.push(Span::styled("◆ ", Style::default().fg(Color::Yellow)));
             }
-            if session.has_claude {
+            if let Some((sym, color)) = claude_marker(session.claude_state, session.has_claude) {
                 title_spans.push(Span::styled(
-                    format!("{} ", CLAUDE_MARKER),
-                    Style::default().fg(CLAUDE_MARKER_COLOR),
+                    format!("{} ", sym),
+                    Style::default().fg(color),
                 ));
             }
 
@@ -457,8 +514,8 @@ fn render_window_preview(frame: &mut Frame, window: &TmuxWindow, area: Rect, is_
         Style::default()
             .fg(Color::Cyan)
             .add_modifier(Modifier::BOLD)
-    } else if window.has_claude {
-        Style::default().fg(CLAUDE_MARKER_COLOR)
+    } else if let Some(color) = claude_border_color(window.claude_state, window.has_claude) {
+        Style::default().fg(color)
     } else if window.active {
         Style::default().fg(Color::Green)
     } else {
@@ -475,10 +532,10 @@ fn render_window_preview(frame: &mut Frame, window: &TmuxWindow, area: Rect, is_
         " {}:{}{} [{}] ",
         window.index, window.name, active_marker, cmd
     ))];
-    if window.has_claude {
+    if let Some((sym, color)) = claude_marker(window.claude_state, window.has_claude) {
         title_spans.push(Span::styled(
-            format!("{} ", CLAUDE_MARKER),
-            Style::default().fg(CLAUDE_MARKER_COLOR),
+            format!("{} ", sym),
+            Style::default().fg(color),
         ));
     }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -5,10 +5,12 @@ use ratatui::{
 
 use crate::app::{ClaudeState, Focus, InputMode, PopupMode, TmuxPane, TmuxWindow, UIState, ViewMode};
 
-/// Orange color used for the "working" Claude marker. Color::Indexed(208) is
-/// the standard 256-color "Orange1" slot, which renders consistently across
-/// terminals that do not honour truecolor.
+/// Orange color used to flag sessions / windows / panes that have a claude
+/// process running. Color::Indexed(208) is the standard 256-color "Orange1"
+/// slot, which renders consistently across terminals that do not honour
+/// truecolor.
 const CLAUDE_MARKER_COLOR: Color = Color::Indexed(208);
+const CLAUDE_MARKER: &str = "●";
 
 /// Braille "dots" spinner frames (cli-spinners `dots`). Rendered for the
 /// `Working` Claude state so the marker visibly animates.
@@ -40,22 +42,29 @@ fn claude_color(state: ClaudeState) -> Color {
     }
 }
 
-/// The marker glyph + color to show for a node given its Claude hook state.
-/// Returns `None` when there is no state to show.
-fn claude_marker(state: Option<ClaudeState>) -> Option<(&'static str, Color)> {
-    let state = state?;
-    let sym = match state {
-        ClaudeState::Working => spinner_frame(),
-        ClaudeState::Waiting => "◆",
-        ClaudeState::Done => "●",
-        ClaudeState::Error => "✗",
-    };
-    Some((sym, claude_color(state)))
+/// The marker glyph + color to show for a node, given its hook state and
+/// whether a claude process was detected. Hook state wins; otherwise we fall
+/// back to the plain "claude is running" marker so behaviour is unchanged when
+/// hooks are not installed. Returns `None` when there is nothing to show.
+fn claude_marker(state: Option<ClaudeState>, has_claude: bool) -> Option<(&'static str, Color)> {
+    match state {
+        Some(ClaudeState::Working) => Some((spinner_frame(), CLAUDE_MARKER_COLOR)),
+        Some(ClaudeState::Waiting) => Some(("◆", claude_color(ClaudeState::Waiting))),
+        Some(ClaudeState::Done) => Some(("●", claude_color(ClaudeState::Done))),
+        Some(ClaudeState::Error) => Some(("✗", claude_color(ClaudeState::Error))),
+        None if has_claude => Some((CLAUDE_MARKER, CLAUDE_MARKER_COLOR)),
+        None => None,
+    }
 }
 
-/// Border accent color for a node based on its Claude state, if any.
-fn claude_border_color(state: Option<ClaudeState>) -> Option<Color> {
-    state.map(claude_color)
+/// Border accent color for a node based on its Claude state, falling back to
+/// the plain claude color when only a process was detected.
+fn claude_border_color(state: Option<ClaudeState>, has_claude: bool) -> Option<Color> {
+    match state {
+        Some(s) => Some(claude_color(s)),
+        None if has_claude => Some(CLAUDE_MARKER_COLOR),
+        None => None,
+    }
 }
 
 // =============================================================================
@@ -134,12 +143,7 @@ fn render_sessions_list(frame: &mut Frame, state: &mut UIState, area: Rect) {
                 Style::default()
             };
             let mut spans = vec![Span::raw(session.name.clone())];
-            if session.attached {
-                spans.push(Span::styled(" ●", Style::default().fg(Color::Green)));
-            } else if session.unread {
-                spans.push(Span::styled(" ◆", Style::default().fg(Color::Yellow)));
-            }
-            if let Some((sym, color)) = claude_marker(session.claude_state) {
+            if let Some((sym, color)) = claude_marker(session.claude_state, session.has_claude) {
                 spans.push(Span::styled(
                     format!(" {}", sym),
                     Style::default().fg(color),
@@ -185,17 +189,13 @@ fn render_windows_list(frame: &mut Frame, state: &mut UIState, area: Rect) {
         .iter()
         .enumerate()
         .map(|(i, window)| {
-            let active_marker = if window.active { " *" } else { "" };
             let style = if i == state.selected_window {
                 Style::default().bg(Color::DarkGray).fg(Color::White)
             } else {
                 Style::default()
             };
-            let mut spans = vec![Span::raw(format!(
-                "{}:{}{}",
-                window.index, window.name, active_marker
-            ))];
-            if let Some((sym, color)) = claude_marker(window.claude_state) {
+            let mut spans = vec![Span::raw(format!("{}:{}", window.index, window.name))];
+            if let Some((sym, color)) = claude_marker(window.claude_state, window.has_claude) {
                 spans.push(Span::styled(
                     format!(" {}", sym),
                     Style::default().fg(color),
@@ -244,17 +244,16 @@ fn render_panes_list(frame: &mut Frame, state: &mut UIState, area: Rect) {
         .iter()
         .enumerate()
         .map(|(i, pane)| {
-            let active_marker = if pane.active { " *" } else { "" };
             let style = if i == state.selected_pane {
                 Style::default().bg(Color::DarkGray).fg(Color::White)
             } else {
                 Style::default()
             };
             let mut spans = vec![Span::raw(format!(
-                "{}:{}{} [{}]",
-                pane.index, pane.id, active_marker, pane.current_command
+                "{}:{} [{}]",
+                pane.index, pane.id, pane.current_command
             ))];
-            if let Some((sym, color)) = claude_marker(pane.claude_state) {
+            if let Some((sym, color)) = claude_marker(pane.claude_state, pane.has_claude) {
                 spans.push(Span::styled(
                     format!(" {}", sym),
                     Style::default().fg(color),
@@ -397,28 +396,21 @@ fn render_multi_preview(frame: &mut Frame, state: &UIState) {
         {
             let is_selected_session = session_idx == state.multi_session;
 
-            // Session block style. Claude-running sessions are highlighted in
-            // orange unless they are the currently selected session (selection
-            // colour wins so the user does not lose track of focus).
+            // Session block style. Sessions running Claude are accented with
+            // their Claude state colour unless they are the currently selected
+            // session (selection colour wins so focus is never lost).
             let session_border_style = if is_selected_session {
                 Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)
             } else if let Some(color) =
-                claude_border_color(session.claude_state)
+                claude_border_color(session.claude_state, session.has_claude)
             {
                 Style::default().fg(color)
-            } else if session.attached {
-                Style::default().fg(Color::Green)
             } else {
                 Style::default().fg(Color::DarkGray)
             };
 
             let mut title_spans = vec![Span::raw(format!(" {} ", session.name))];
-            if session.attached {
-                title_spans.push(Span::styled("● ", Style::default().fg(Color::Green)));
-            } else if session.unread {
-                title_spans.push(Span::styled("◆ ", Style::default().fg(Color::Yellow)));
-            }
-            if let Some((sym, color)) = claude_marker(session.claude_state) {
+            if let Some((sym, color)) = claude_marker(session.claude_state, session.has_claude) {
                 title_spans.push(Span::styled(
                     format!("{} ", sym),
                     Style::default().fg(color),
@@ -505,25 +497,22 @@ fn render_window_preview(frame: &mut Frame, window: &TmuxWindow, area: Rect, is_
         Style::default()
             .fg(Color::Cyan)
             .add_modifier(Modifier::BOLD)
-    } else if let Some(color) = claude_border_color(window.claude_state) {
+    } else if let Some(color) = claude_border_color(window.claude_state, window.has_claude) {
         Style::default().fg(color)
-    } else if window.active {
-        Style::default().fg(Color::Green)
     } else {
         Style::default().fg(Color::DarkGray)
     };
 
-    let active_marker = if window.active { " *" } else { "" };
     let cmd = window
         .get_active_pane()
         .map(|p| p.current_command.as_str())
         .unwrap_or("");
 
     let mut title_spans = vec![Span::raw(format!(
-        " {}:{}{} [{}] ",
-        window.index, window.name, active_marker, cmd
+        " {}:{} [{}] ",
+        window.index, window.name, cmd
     ))];
-    if let Some((sym, color)) = claude_marker(window.claude_state) {
+    if let Some((sym, color)) = claude_marker(window.claude_state, window.has_claude) {
         title_spans.push(Span::styled(
             format!("{} ", sym),
             Style::default().fg(color),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -5,12 +5,10 @@ use ratatui::{
 
 use crate::app::{ClaudeState, Focus, InputMode, PopupMode, TmuxPane, TmuxWindow, UIState, ViewMode};
 
-/// Orange color used to flag sessions / windows / panes that have a claude
-/// process running. Color::Indexed(208) is the standard 256-color "Orange1"
-/// slot, which renders consistently across terminals that do not honour
-/// truecolor.
+/// Orange color used for the "working" Claude marker. Color::Indexed(208) is
+/// the standard 256-color "Orange1" slot, which renders consistently across
+/// terminals that do not honour truecolor.
 const CLAUDE_MARKER_COLOR: Color = Color::Indexed(208);
-const CLAUDE_MARKER: &str = "●";
 
 /// Braille "dots" spinner frames (cli-spinners `dots`). Rendered for the
 /// `Working` Claude state so the marker visibly animates.
@@ -42,29 +40,22 @@ fn claude_color(state: ClaudeState) -> Color {
     }
 }
 
-/// The marker glyph + color to show for a node, given its hook state and
-/// whether a claude process was detected. Hook state wins; otherwise we fall
-/// back to the plain "claude is running" marker so behaviour is unchanged when
-/// hooks are not installed. Returns `None` when there is nothing to show.
-fn claude_marker(state: Option<ClaudeState>, has_claude: bool) -> Option<(&'static str, Color)> {
-    match state {
-        Some(ClaudeState::Working) => Some((spinner_frame(), CLAUDE_MARKER_COLOR)),
-        Some(ClaudeState::Waiting) => Some(("◆", claude_color(ClaudeState::Waiting))),
-        Some(ClaudeState::Done) => Some(("●", claude_color(ClaudeState::Done))),
-        Some(ClaudeState::Error) => Some(("✗", claude_color(ClaudeState::Error))),
-        None if has_claude => Some((CLAUDE_MARKER, CLAUDE_MARKER_COLOR)),
-        None => None,
-    }
+/// The marker glyph + color to show for a node given its Claude hook state.
+/// Returns `None` when there is no state to show.
+fn claude_marker(state: Option<ClaudeState>) -> Option<(&'static str, Color)> {
+    let state = state?;
+    let sym = match state {
+        ClaudeState::Working => spinner_frame(),
+        ClaudeState::Waiting => "◆",
+        ClaudeState::Done => "●",
+        ClaudeState::Error => "✗",
+    };
+    Some((sym, claude_color(state)))
 }
 
-/// Border accent color for a node based on its Claude state, falling back to
-/// the plain claude color when only a process was detected.
-fn claude_border_color(state: Option<ClaudeState>, has_claude: bool) -> Option<Color> {
-    match state {
-        Some(s) => Some(claude_color(s)),
-        None if has_claude => Some(CLAUDE_MARKER_COLOR),
-        None => None,
-    }
+/// Border accent color for a node based on its Claude state, if any.
+fn claude_border_color(state: Option<ClaudeState>) -> Option<Color> {
+    state.map(claude_color)
 }
 
 // =============================================================================
@@ -148,7 +139,7 @@ fn render_sessions_list(frame: &mut Frame, state: &mut UIState, area: Rect) {
             } else if session.unread {
                 spans.push(Span::styled(" ◆", Style::default().fg(Color::Yellow)));
             }
-            if let Some((sym, color)) = claude_marker(session.claude_state, session.has_claude) {
+            if let Some((sym, color)) = claude_marker(session.claude_state) {
                 spans.push(Span::styled(
                     format!(" {}", sym),
                     Style::default().fg(color),
@@ -204,7 +195,7 @@ fn render_windows_list(frame: &mut Frame, state: &mut UIState, area: Rect) {
                 "{}:{}{}",
                 window.index, window.name, active_marker
             ))];
-            if let Some((sym, color)) = claude_marker(window.claude_state, window.has_claude) {
+            if let Some((sym, color)) = claude_marker(window.claude_state) {
                 spans.push(Span::styled(
                     format!(" {}", sym),
                     Style::default().fg(color),
@@ -263,7 +254,7 @@ fn render_panes_list(frame: &mut Frame, state: &mut UIState, area: Rect) {
                 "{}:{}{} [{}]",
                 pane.index, pane.id, active_marker, pane.current_command
             ))];
-            if let Some((sym, color)) = claude_marker(pane.claude_state, pane.has_claude) {
+            if let Some((sym, color)) = claude_marker(pane.claude_state) {
                 spans.push(Span::styled(
                     format!(" {}", sym),
                     Style::default().fg(color),
@@ -412,7 +403,7 @@ fn render_multi_preview(frame: &mut Frame, state: &UIState) {
             let session_border_style = if is_selected_session {
                 Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)
             } else if let Some(color) =
-                claude_border_color(session.claude_state, session.has_claude)
+                claude_border_color(session.claude_state)
             {
                 Style::default().fg(color)
             } else if session.attached {
@@ -427,7 +418,7 @@ fn render_multi_preview(frame: &mut Frame, state: &UIState) {
             } else if session.unread {
                 title_spans.push(Span::styled("◆ ", Style::default().fg(Color::Yellow)));
             }
-            if let Some((sym, color)) = claude_marker(session.claude_state, session.has_claude) {
+            if let Some((sym, color)) = claude_marker(session.claude_state) {
                 title_spans.push(Span::styled(
                     format!("{} ", sym),
                     Style::default().fg(color),
@@ -514,7 +505,7 @@ fn render_window_preview(frame: &mut Frame, window: &TmuxWindow, area: Rect, is_
         Style::default()
             .fg(Color::Cyan)
             .add_modifier(Modifier::BOLD)
-    } else if let Some(color) = claude_border_color(window.claude_state, window.has_claude) {
+    } else if let Some(color) = claude_border_color(window.claude_state) {
         Style::default().fg(color)
     } else if window.active {
         Style::default().fg(Color::Green)
@@ -532,7 +523,7 @@ fn render_window_preview(frame: &mut Frame, window: &TmuxWindow, area: Rect, is_
         " {}:{}{} [{}] ",
         window.index, window.name, active_marker, cmd
     ))];
-    if let Some((sym, color)) = claude_marker(window.claude_state, window.has_claude) {
+    if let Some((sym, color)) = claude_marker(window.claude_state) {
         title_spans.push(Span::styled(
             format!("{} ", sym),
             Style::default().fg(color),


### PR DESCRIPTION
## 概要

Claude Code の **hook** を使って、treeview 上のマーカーを Claude の状態に応じて動的に変化させる機能を追加します。

これまではセッション/ウィンドウ/ペインに「claude が動いているか否か」の静的マーカーが付くだけでしたが、hook を導入すると Claude が「何をしているか」（作業中・入力待ち・完了・エラー）がマーカーで分かるようになります。

## マーカー

状態は**色ではなく形（グリフ）**で区別します。マーカーは単一色で、端末のパレットや色覚に依存せず読み取れます。

| マーカー | 状態 | 意味 |
| --- | --- | --- |
| `⠋⠙⠹…`（アニメーション） | Working | プロンプト送信 / ツール実行中 |
| `◆` | Waiting | ユーザーの操作待ち（許可待ち / アイドル） |
| `✓` | Done | ターン完了 |
| `✗` | Error | エラーで終了 |
| `●` | Running | claude プロセス検出のみ（hook 未導入時のフォールバック） |

ウィンドウ / セッションは子の最も注目すべき状態に集約されます（waiting > error > working > done）。

## 仕組み

- **`tmux-deck hook report`**: hook の JSON を stdin で受け取り、`$TMUX_PANE` をキーに `$XDG_STATE_HOME/tmux-deck/claude/<pane>.json` へ状態を記録。`SessionEnd` でマーカーをクリア、古いファイルは自動掃除。tmux 外（`$TMUX_PANE` なし）では no-op。
- **`tmux-deck hook install [--project]`**: Claude の `settings.json`（既定はユーザーグローバル `~/.claude/settings.json`）へ7イベント分の hook を冪等にマージ。既存設定は保持。
- **TUI 側**: リフレッシュ tick ごとに状態ファイルを読み込み、treeview に反映。`Working` は壁時計時間ベースの braille dots スピナーで描画し、スピナーが動いている間だけ高頻度（80ms）再描画する（アイドル時はイベント駆動のまま）。
- hook 未導入時は従来のプロセス検出（`●`）にフォールバックするので、既定動作は変わりません。

## その他の変更

- セッション管理用のマーカー（attached の `●`、unread の `◆`、active の `*`）を削除し、treeview を Claude マーカーのみに整理。未使用になったフィールドも除去。

## テスト

- `cargo build` / `cargo clippy --all-targets` 警告ゼロ
- `cargo test` 8件パス（hook イベントのマッピング、状態の集約、settings.json マージの冪等性 / 既存保持 など）
- reporter が正しい状態ファイルを生成し `SessionEnd` で削除されること、installer が妥当な settings.json を生成することを実出力で確認

## ドキュメント

- `README.md` に Claude Code Integration セクション（マーカー一覧・セットアップ手順・仕組み）を追加
- `docs/claude-hook-treeview-plan.md` に設計計画を追加

https://claude.ai/code/session_01D2kS8yBhrPfagemBRizfLg

---
_Generated by [Claude Code](https://claude.ai/code/session_01D2kS8yBhrPfagemBRizfLg)_