### PR TITLE
feat: TreeView のセッショングループ機能

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tmux-deck"
-version = "0.1.8"
+version = "0.0.0"
 edition = "2024"
 authors = ["tkcd <goriponikeike55@gmail.com>"]
 repository = "https://github.com/takeshid/tmux-deck"

--- a/src/actor/tmux_actor.rs
+++ b/src/actor/tmux_actor.rs
@@ -826,6 +826,9 @@ fn build_sessions(stdout: &str) -> Vec<TmuxSession> {
                 has_claude: false,
                 last_attached: s.last_attached,
                 activity: s.activity,
+                // Group labels are applied tmux-deck-side in UIState once the
+                // refreshed sessions reach the UI; the tmux layer is unaware.
+                group: None,
             })
         })
         .collect()

--- a/src/actor/ui_actor.rs
+++ b/src/actor/ui_actor.rs
@@ -162,13 +162,23 @@ impl UIActor {
         popup_mode: PopupMode,
     ) -> Result<bool> {
         match popup_mode {
-            PopupMode::NewSession | PopupMode::RenameSession => {
+            PopupMode::NewSession | PopupMode::RenameSession | PopupMode::GroupSession => {
                 match key.code {
                     KeyCode::Esc => {
                         self.state.close_popup();
                         self.refresh_control.resume();
                     }
                     KeyCode::Enter => {
+                        // GroupSession is handled entirely tmux-deck-side: no
+                        // tmux command and no RefreshAll, since grouping does
+                        // not change anything tmux knows about.
+                        if popup_mode == PopupMode::GroupSession {
+                            let group = self.state.get_group_session_input();
+                            self.state.assign_selected_group(group);
+                            self.state.close_popup();
+                            self.refresh_control.resume();
+                            return Ok(false);
+                        }
                         if popup_mode == PopupMode::NewSession {
                             let name = self.state.get_new_session_name();
                             if !name.is_empty() {
@@ -177,6 +187,9 @@ impl UIActor {
                         } else if let Some((old_name, new_name)) =
                             self.state.get_rename_session_info()
                         {
+                            // Carry the group label across the rename so the
+                            // session does not silently fall out of its group.
+                            self.state.groups.rename_session(&old_name, &new_name);
                             let _ = self
                                 .tmux_cmd_tx
                                 .send(TmuxCommand::RenameSession { old_name, new_name })
@@ -205,6 +218,9 @@ impl UIActor {
                     }
                     KeyCode::Enter => {
                         if let Some(name) = self.state.get_kill_session_name() {
+                            // Drop the killed session's group assignment so the
+                            // store does not keep stale entries around.
+                            self.state.groups.forget(&name);
                             let _ = self.tmux_cmd_tx.send(TmuxCommand::KillSession { name }).await;
                             // Refresh after operation
                             let _ = self.tmux_cmd_tx.send(TmuxCommand::RefreshAll).await;
@@ -262,6 +278,13 @@ impl UIActor {
                         && self.state.focus == Focus::Sessions =>
                 {
                     self.state.cycle_session_sort();
+                }
+                KeyCode::Char('g')
+                    if self.state.view_mode == ViewMode::TreeView
+                        && self.state.focus == Focus::Sessions =>
+                {
+                    self.state.open_group_session_popup();
+                    self.refresh_control.pause();
                 }
                 KeyCode::Char(' ') => {
                     self.state.handle_space_press();

--- a/src/actor/ui_actor.rs
+++ b/src/actor/ui_actor.rs
@@ -8,7 +8,7 @@ use ratatui::backend::CrosstermBackend;
 use tokio::sync::{mpsc, oneshot};
 
 use crate::actor::messages::{RefreshControl, TmuxCommand, TmuxResponse, UIEvent};
-use crate::app::{Focus, InputMode, PopupMode, UIState, ViewMode};
+use crate::app::{Focus, GroupChoice, InputMode, PopupMode, UIState, ViewMode};
 use crate::ui::render_ui;
 
 // =============================================================================
@@ -182,17 +182,46 @@ impl UIActor {
         popup_mode: PopupMode,
     ) -> Result<bool> {
         match popup_mode {
-            PopupMode::NewSession | PopupMode::RenameSession | PopupMode::GroupSession => {
+            PopupMode::GroupSession => {
+                // Selecting an existing group (or "ungroup") is handled entirely
+                // tmux-deck-side: no tmux command and no RefreshAll, since
+                // grouping does not change anything tmux knows about.
+                match key.code {
+                    KeyCode::Esc => {
+                        self.state.close_popup();
+                        self.refresh_control.resume();
+                    }
+                    KeyCode::Up | KeyCode::Char('k') => self.state.group_choice_up(),
+                    KeyCode::Down | KeyCode::Char('j') => self.state.group_choice_down(),
+                    KeyCode::Enter => match self.state.selected_group_choice() {
+                        GroupChoice::Existing(group) => {
+                            self.state.assign_selected_group(Some(group));
+                            self.state.close_popup();
+                            self.refresh_control.resume();
+                        }
+                        GroupChoice::Ungrouped => {
+                            self.state.assign_selected_group(None);
+                            self.state.close_popup();
+                            self.refresh_control.resume();
+                        }
+                        // Switch to text entry; stay in popup so the refresh
+                        // control remains paused until the name is confirmed.
+                        GroupChoice::New => self.state.begin_new_group_entry(),
+                    },
+                    _ => {}
+                }
+            }
+            PopupMode::NewSession | PopupMode::RenameSession | PopupMode::NewGroup => {
                 match key.code {
                     KeyCode::Esc => {
                         self.state.close_popup();
                         self.refresh_control.resume();
                     }
                     KeyCode::Enter => {
-                        // GroupSession is handled entirely tmux-deck-side: no
+                        // A new group is handled entirely tmux-deck-side: no
                         // tmux command and no RefreshAll, since grouping does
                         // not change anything tmux knows about.
-                        if popup_mode == PopupMode::GroupSession {
+                        if popup_mode == PopupMode::NewGroup {
                             let group = self.state.get_group_session_input();
                             self.state.assign_selected_group(group);
                             self.state.close_popup();

--- a/src/actor/ui_actor.rs
+++ b/src/actor/ui_actor.rs
@@ -251,6 +251,17 @@ impl UIActor {
     async fn handle_normal_mode_key(&mut self, key: event::KeyEvent) -> Result<bool> {
         let is_ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
 
+        // `za` fold chord: a pending `z` followed by `a` toggles the current
+        // group's fold. Any other key cancels the chord and is then processed
+        // normally below.
+        if self.state.pending_z {
+            self.state.pending_z = false;
+            if !is_ctrl && key.code == KeyCode::Char('a') {
+                self.state.toggle_fold_current_group();
+                return Ok(false);
+            }
+        }
+
         if is_ctrl {
             match key.code {
                 KeyCode::Char('n') => {
@@ -285,6 +296,13 @@ impl UIActor {
                 {
                     self.state.open_group_session_popup();
                     self.refresh_control.pause();
+                }
+                KeyCode::Char('z')
+                    if self.state.view_mode == ViewMode::TreeView
+                        && self.state.focus == Focus::Sessions =>
+                {
+                    // Begin the `za` fold chord; the next key resolves it.
+                    self.state.pending_z = true;
                 }
                 KeyCode::Char(' ') => {
                     self.state.handle_space_press();

--- a/src/app.rs
+++ b/src/app.rs
@@ -308,8 +308,25 @@ pub enum PopupMode {
     RenameSession,
     /// Confirming session kill
     ConfirmKill,
-    /// Assigning the selected session to a tmux-deck group
+    /// Choosing a group for the selected session from a list of existing
+    /// groups (plus "ungroup" and "create new" entries).
     GroupSession,
+    /// Typing the name of a brand-new group, reached from the GroupSession
+    /// list via the "New group" entry.
+    NewGroup,
+}
+
+/// The entry highlighted in the [`PopupMode::GroupSession`] selection list.
+/// The list shows every existing group, then an "Ungrouped" entry that clears
+/// the assignment, then a "New group" entry that switches to text entry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GroupChoice {
+    /// Assign the session to an existing group of this name.
+    Existing(String),
+    /// Remove the session from any group.
+    Ungrouped,
+    /// Create a new group (switches the popup to text entry).
+    New,
 }
 
 /// A single rendered row in the Sessions list. Grouping inserts non-selectable
@@ -379,6 +396,12 @@ pub struct UIState {
     // Popup state
     pub popup_mode: Option<PopupMode>,
     pub confirm_yes_selected: bool,
+    /// Existing group names offered in the GroupSession selection list,
+    /// snapshotted when the popup opens so navigation stays stable.
+    pub group_choices: Vec<String>,
+    /// Index of the highlighted entry in the GroupSession list. Entries are
+    /// `group_choices` followed by the "Ungrouped" and "New group" entries.
+    pub group_choice_index: usize,
 }
 
 impl UIState {
@@ -413,6 +436,8 @@ impl UIState {
             input_cursor: 0,
 
             popup_mode: None,
+            group_choices: Vec::new(),
+            group_choice_index: 0,
             confirm_yes_selected: false,
         };
         state.session_list_state.select(Some(0));
@@ -574,12 +599,60 @@ impl UIState {
     }
 
     pub fn open_group_session_popup(&mut self) {
-        if let Some(session) = self.sessions.get(self.selected_session) {
-            self.popup_mode = Some(PopupMode::GroupSession);
-            // Prefill with the current group so editing/clearing is natural.
-            self.input_buffer = session.group.clone().unwrap_or_default();
-            self.input_cursor = self.input_buffer.len();
+        let Some(session) = self.sessions.get(self.selected_session) else {
+            return;
+        };
+        let current = session.group.clone();
+        self.popup_mode = Some(PopupMode::GroupSession);
+        self.group_choices = self.groups.group_names();
+        // Highlight the session's current group by default, falling back to the
+        // "Ungrouped" entry (which sits just past the existing groups) when the
+        // session is not grouped yet.
+        self.group_choice_index = match current {
+            Some(g) => self
+                .group_choices
+                .iter()
+                .position(|name| *name == g)
+                .unwrap_or(self.group_choices.len()),
+            None => self.group_choices.len(),
+        };
+        self.input_buffer.clear();
+        self.input_cursor = 0;
+    }
+
+    /// Total number of entries in the GroupSession list: every existing group,
+    /// then the "Ungrouped" and "New group" entries.
+    pub fn group_choice_count(&self) -> usize {
+        self.group_choices.len() + 2
+    }
+
+    /// The entry currently highlighted in the GroupSession list.
+    pub fn selected_group_choice(&self) -> GroupChoice {
+        let n = self.group_choices.len();
+        if self.group_choice_index < n {
+            GroupChoice::Existing(self.group_choices[self.group_choice_index].clone())
+        } else if self.group_choice_index == n {
+            GroupChoice::Ungrouped
+        } else {
+            GroupChoice::New
         }
+    }
+
+    pub fn group_choice_up(&mut self) {
+        let n = self.group_choice_count();
+        self.group_choice_index = (self.group_choice_index + n - 1) % n;
+    }
+
+    pub fn group_choice_down(&mut self) {
+        let n = self.group_choice_count();
+        self.group_choice_index = (self.group_choice_index + 1) % n;
+    }
+
+    /// Switch the open GroupSession popup into text entry for a new group name.
+    pub fn begin_new_group_entry(&mut self) {
+        self.popup_mode = Some(PopupMode::NewGroup);
+        self.input_buffer.clear();
+        self.input_cursor = 0;
     }
 
     pub fn open_kill_session_popup(&mut self) {
@@ -594,6 +667,8 @@ impl UIState {
         self.input_buffer.clear();
         self.input_cursor = 0;
         self.confirm_yes_selected = false;
+        self.group_choices.clear();
+        self.group_choice_index = 0;
     }
 
     pub fn toggle_confirm_selection(&mut self) {
@@ -1181,5 +1256,56 @@ mod tests {
         assert_eq!(ordered, vec!["b", "a"]);
         // Selection still tracks "b" after the reorder.
         assert_eq!(state.sessions[state.selected_session].name, "b");
+    }
+
+    #[test]
+    fn group_popup_lists_existing_groups_and_highlights_current() {
+        let state = state_with(
+            &["a", "b", "c"],
+            &[("a", "work"), ("b", "personal"), ("c", "work")],
+        );
+        // Sorted, deduplicated existing groups.
+        assert_eq!(state.groups.group_names(), vec!["personal", "work"]);
+
+        let mut state = state;
+        state.selected_session = state.sessions.iter().position(|s| s.name == "b").unwrap();
+        state.open_group_session_popup();
+        assert_eq!(state.popup_mode, Some(PopupMode::GroupSession));
+        // "b" is in "personal", so that entry starts highlighted.
+        assert_eq!(
+            state.selected_group_choice(),
+            GroupChoice::Existing("personal".to_string())
+        );
+        // Entries: 2 groups + Ungrouped + New.
+        assert_eq!(state.group_choice_count(), 4);
+    }
+
+    #[test]
+    fn group_popup_defaults_to_ungrouped_for_ungrouped_session() {
+        let mut state = state_with(&["a", "b"], &[("b", "work")]);
+        state.selected_session = state.sessions.iter().position(|s| s.name == "a").unwrap();
+        state.open_group_session_popup();
+        // Index sits on the "Ungrouped" entry, just past the single group.
+        assert_eq!(state.selected_group_choice(), GroupChoice::Ungrouped);
+    }
+
+    #[test]
+    fn group_choice_navigation_wraps_and_reaches_new() {
+        let mut state = state_with(&["a"], &[("a", "work")]);
+        state.open_group_session_popup();
+        // Entries: ["work", Ungrouped, New]. Starts on "work".
+        assert_eq!(
+            state.selected_group_choice(),
+            GroupChoice::Existing("work".to_string())
+        );
+        state.group_choice_up(); // wraps to last entry
+        assert_eq!(state.selected_group_choice(), GroupChoice::New);
+        state.group_choice_down(); // wraps back to first
+        assert_eq!(
+            state.selected_group_choice(),
+            GroupChoice::Existing("work".to_string())
+        );
+        state.group_choice_down();
+        assert_eq!(state.selected_group_choice(), GroupChoice::Ungrouped);
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -623,17 +623,39 @@ impl UIState {
         self.any_grouped() && self.collapsed_groups.contains(group)
     }
 
-    /// Whether the session at `index` is shown (its group is not folded).
-    fn session_visible(&self, index: usize) -> bool {
+    /// Whether the session at `index` is the first of its group in the current
+    /// ordering — the row a folded group collapses onto.
+    fn is_group_head(&self, index: usize) -> bool {
         match self.sessions.get(index) {
-            Some(s) => !self.is_collapsed(&s.group),
             None => false,
+            Some(s) => index == 0 || self.sessions[index - 1].group != s.group,
         }
     }
 
+    /// Whether the cursor may rest on the session at `index`. A session is a
+    /// stop when it is visible, or when it is the head of a folded group — in
+    /// which case the cursor visually sits on that group's (collapsed) header,
+    /// so the group can be re-expanded with `za`.
+    fn is_cursor_stop(&self, index: usize) -> bool {
+        match self.sessions.get(index) {
+            None => false,
+            Some(s) => !self.is_collapsed(&s.group) || self.is_group_head(index),
+        }
+    }
+
+    /// Whether the selection currently sits on a folded group's header rather
+    /// than a visible session. Used by the renderer to highlight the header.
+    pub fn selection_on_folded_header(&self) -> bool {
+        self.sessions
+            .get(self.selected_session)
+            .map(|s| self.is_collapsed(&s.group))
+            .unwrap_or(false)
+    }
+
     /// Toggle the fold state of the group containing the selected session.
-    /// Folding a group hides its members, so the selection is moved onto the
-    /// nearest still-visible session.
+    /// When folding, the selection collapses onto the group's head so the
+    /// cursor stays on the (now folded) header and the group can be reopened
+    /// with another `za`.
     pub fn toggle_fold_current_group(&mut self) {
         if !self.any_grouped() {
             return;
@@ -645,38 +667,25 @@ impl UIState {
         if self.collapsed_groups.contains(&group) {
             self.collapsed_groups.remove(&group);
         } else {
-            self.collapsed_groups.insert(group);
-            self.select_nearest_visible_session();
+            self.collapsed_groups.insert(group.clone());
+            // Park the selection on the group's head so it remains a valid
+            // cursor stop (the folded header) instead of a hidden member.
+            if let Some(head) = self.sessions.iter().position(|s| s.group == group) {
+                self.selected_session = head;
+                self.selected_window = 0;
+                self.selected_pane = 0;
+                self.window_list_state.select(Some(0));
+                self.pane_list_state.select(Some(0));
+            }
         }
     }
 
-    fn next_visible_session(&self, from: usize) -> Option<usize> {
-        ((from + 1)..self.sessions.len()).find(|&i| self.session_visible(i))
+    fn next_cursor_stop(&self, from: usize) -> Option<usize> {
+        ((from + 1)..self.sessions.len()).find(|&i| self.is_cursor_stop(i))
     }
 
-    fn prev_visible_session(&self, from: usize) -> Option<usize> {
-        (0..from).rev().find(|&i| self.session_visible(i))
-    }
-
-    /// If the selected session is hidden by a fold, move the selection to the
-    /// closest visible session (preferring the one just after it). When every
-    /// group is folded the selection is left as-is and simply shows no
-    /// highlight.
-    fn select_nearest_visible_session(&mut self) {
-        if self.session_visible(self.selected_session) {
-            return;
-        }
-        if let Some(i) = self
-            .next_visible_session(self.selected_session)
-            .or_else(|| self.prev_visible_session(self.selected_session))
-        {
-            self.selected_session = i;
-            self.selected_window = 0;
-            self.selected_pane = 0;
-            self.window_list_state.select(Some(0));
-            self.pane_list_state.select(Some(0));
-        }
-        self.session_list_state.select(Some(self.selected_session));
+    fn prev_cursor_stop(&self, from: usize) -> Option<usize> {
+        (0..from).rev().find(|&i| self.is_cursor_stop(i))
     }
 
     /// Build the rendered Sessions rows, inserting group headers and dropping
@@ -799,7 +808,7 @@ impl UIState {
     pub fn tree_move_up(&mut self) {
         match self.focus {
             Focus::Sessions => {
-                if let Some(prev) = self.prev_visible_session(self.selected_session) {
+                if let Some(prev) = self.prev_cursor_stop(self.selected_session) {
                     self.selected_session = prev;
                     self.selected_window = 0;
                     self.selected_pane = 0;
@@ -828,7 +837,7 @@ impl UIState {
     pub fn tree_move_down(&mut self) {
         match self.focus {
             Focus::Sessions => {
-                if let Some(next) = self.next_visible_session(self.selected_session) {
+                if let Some(next) = self.next_cursor_stop(self.selected_session) {
                     self.selected_session = next;
                     self.selected_window = 0;
                     self.selected_pane = 0;
@@ -1019,14 +1028,14 @@ mod tests {
             })
             .collect();
         assert_eq!(visible_sessions, vec!["b"]);
-        // Selection was relocated out of the folded group onto a visible one.
-        assert!(state.session_visible(state.selected_session));
+        // Selection parks on the folded group's head, so the cursor sits on the
+        // (collapsed) "work" header and can re-open it.
+        assert!(state.selection_on_folded_header());
+        assert_eq!(state.sessions[state.selected_session].group.as_deref(), Some("work"));
 
-        // Folding again (after selecting back into work) toggles it open.
-        state.toggle_fold_current_group(); // currently on "b" (play) -> folds play
-        // Re-expand work by selecting a work session is impossible while folded;
-        // instead toggle work directly via its key state:
-        state.collapsed_groups.remove(&Some("work".to_string()));
+        // Toggling again from the folded header re-expands the group — this is
+        // the regression that previously had no way to recover.
+        state.toggle_fold_current_group();
         let rows = state.session_rows();
         let names: Vec<&str> = rows
             .iter()
@@ -1036,21 +1045,27 @@ mod tests {
             })
             .collect();
         assert!(names.contains(&"a") && names.contains(&"c"));
+        assert!(!state.selection_on_folded_header());
     }
 
     #[test]
-    fn navigation_skips_folded_sessions() {
+    fn navigation_lands_on_folded_group_then_reopens() {
         let mut state = state_with(
             &["a", "b", "c"],
             &[("a", "work"), ("c", "work"), ("b", "play")],
         );
-        // Order is play(b), work(a,c). Fold work.
+        // Order is play(b), work(a,c). Fold work (selection parks on work head).
         state.selected_session = state.sessions.iter().position(|s| s.name == "a").unwrap();
         state.toggle_fold_current_group();
-        // Start on the only visible session "b" and move down: nowhere visible.
+        // From the visible "b", moving down stops on the folded work header
+        // rather than skipping it entirely.
         state.selected_session = state.sessions.iter().position(|s| s.name == "b").unwrap();
         state.tree_move_down();
-        assert_eq!(state.sessions[state.selected_session].name, "b");
+        assert!(state.selection_on_folded_header());
+        assert_eq!(state.sessions[state.selected_session].group.as_deref(), Some("work"));
+        // And `za` there expands it back.
+        state.toggle_fold_current_group();
+        assert!(!state.selection_on_folded_header());
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::time::{Duration, Instant};
 
 use ansi_to_tui::IntoText;
@@ -242,7 +243,13 @@ pub enum PopupMode {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SessionRow {
     /// A group heading. `group` is `None` for the implicit ungrouped bucket.
-    Header { group: Option<String>, count: usize },
+    /// `collapsed` drives the fold indicator and means the member session rows
+    /// are hidden.
+    Header {
+        group: Option<String>,
+        count: usize,
+        collapsed: bool,
+    },
     /// A session, identified by its index into [`UIState::sessions`].
     Session { index: usize },
 }
@@ -271,6 +278,12 @@ pub struct UIState {
 
     /// Persisted tmux-deck-side session grouping (session name -> group).
     pub groups: GroupStore,
+    /// Groups currently folded in the Sessions list. A group key of `None` is
+    /// the implicit "Ungrouped" bucket. Fold state is session-runtime only and
+    /// is not persisted.
+    pub collapsed_groups: HashSet<Option<String>>,
+    /// True after `z` is pressed, awaiting the `a` of the `za` fold chord.
+    pub pending_z: bool,
 
     // MultiPreview state (session_idx, window_idx)
     pub multi_session: usize,
@@ -308,6 +321,8 @@ impl UIState {
             session_sort: SessionSort::default(),
 
             groups: GroupStore::load(),
+            collapsed_groups: HashSet::new(),
+            pending_z: false,
 
             multi_session: 0,
             multi_window: 0,
@@ -589,18 +604,91 @@ impl UIState {
         };
         let name = session.name.clone();
         self.groups.set(&name, group.as_deref());
+        // Reveal the destination group so the user sees the session land, even
+        // if that group was folded.
+        self.collapsed_groups.remove(&group);
         self.apply_group_labels();
         self.resort_sessions_preserve_selection();
     }
 
-    /// Build the rendered Sessions rows, inserting group headers. When no
-    /// session is grouped the result is a flat list of [`SessionRow::Session`]
-    /// rows (no headers), matching the pre-grouping behaviour exactly.
+    /// Whether any session carries a group label. When false there are no
+    /// headers and folding is a no-op (there is nothing to organise yet).
+    fn any_grouped(&self) -> bool {
+        self.sessions.iter().any(|s| s.group.is_some())
+    }
+
+    /// Whether `group` is currently folded. Folding only takes effect once
+    /// real groups exist, so a stray collapsed entry never hides a flat list.
+    fn is_collapsed(&self, group: &Option<String>) -> bool {
+        self.any_grouped() && self.collapsed_groups.contains(group)
+    }
+
+    /// Whether the session at `index` is shown (its group is not folded).
+    fn session_visible(&self, index: usize) -> bool {
+        match self.sessions.get(index) {
+            Some(s) => !self.is_collapsed(&s.group),
+            None => false,
+        }
+    }
+
+    /// Toggle the fold state of the group containing the selected session.
+    /// Folding a group hides its members, so the selection is moved onto the
+    /// nearest still-visible session.
+    pub fn toggle_fold_current_group(&mut self) {
+        if !self.any_grouped() {
+            return;
+        }
+        let Some(session) = self.sessions.get(self.selected_session) else {
+            return;
+        };
+        let group = session.group.clone();
+        if self.collapsed_groups.contains(&group) {
+            self.collapsed_groups.remove(&group);
+        } else {
+            self.collapsed_groups.insert(group);
+            self.select_nearest_visible_session();
+        }
+    }
+
+    fn next_visible_session(&self, from: usize) -> Option<usize> {
+        ((from + 1)..self.sessions.len()).find(|&i| self.session_visible(i))
+    }
+
+    fn prev_visible_session(&self, from: usize) -> Option<usize> {
+        (0..from).rev().find(|&i| self.session_visible(i))
+    }
+
+    /// If the selected session is hidden by a fold, move the selection to the
+    /// closest visible session (preferring the one just after it). When every
+    /// group is folded the selection is left as-is and simply shows no
+    /// highlight.
+    fn select_nearest_visible_session(&mut self) {
+        if self.session_visible(self.selected_session) {
+            return;
+        }
+        if let Some(i) = self
+            .next_visible_session(self.selected_session)
+            .or_else(|| self.prev_visible_session(self.selected_session))
+        {
+            self.selected_session = i;
+            self.selected_window = 0;
+            self.selected_pane = 0;
+            self.window_list_state.select(Some(0));
+            self.pane_list_state.select(Some(0));
+        }
+        self.session_list_state.select(Some(self.selected_session));
+    }
+
+    /// Build the rendered Sessions rows, inserting group headers and dropping
+    /// the members of folded groups. When no session is grouped the result is a
+    /// flat list of [`SessionRow::Session`] rows (no headers), matching the
+    /// pre-grouping behaviour exactly.
     pub fn session_rows(&self) -> Vec<SessionRow> {
-        let any_grouped = self.sessions.iter().any(|s| s.group.is_some());
+        let any_grouped = self.any_grouped();
         let mut rows = Vec::with_capacity(self.sessions.len());
         let mut current: Option<&Option<String>> = None;
         for (index, session) in self.sessions.iter().enumerate() {
+            let collapsed = any_grouped && self.collapsed_groups.contains(&session.group);
             if any_grouped && current != Some(&session.group) {
                 let count = self
                     .sessions
@@ -610,10 +698,13 @@ impl UIState {
                 rows.push(SessionRow::Header {
                     group: session.group.clone(),
                     count,
+                    collapsed,
                 });
                 current = Some(&session.group);
             }
-            rows.push(SessionRow::Session { index });
+            if !collapsed {
+                rows.push(SessionRow::Session { index });
+            }
         }
         rows
     }
@@ -708,8 +799,8 @@ impl UIState {
     pub fn tree_move_up(&mut self) {
         match self.focus {
             Focus::Sessions => {
-                if self.selected_session > 0 {
-                    self.selected_session -= 1;
+                if let Some(prev) = self.prev_visible_session(self.selected_session) {
+                    self.selected_session = prev;
                     self.selected_window = 0;
                     self.selected_pane = 0;
                     self.window_list_state.select(Some(0));
@@ -737,8 +828,8 @@ impl UIState {
     pub fn tree_move_down(&mut self) {
         match self.focus {
             Focus::Sessions => {
-                if self.selected_session < self.sessions.len().saturating_sub(1) {
-                    self.selected_session += 1;
+                if let Some(next) = self.next_visible_session(self.selected_session) {
+                    self.selected_session = next;
                     self.selected_window = 0;
                     self.selected_pane = 0;
                     self.window_list_state.select(Some(0));
@@ -882,7 +973,7 @@ mod tests {
         let labels: Vec<String> = rows
             .iter()
             .filter_map(|r| match r {
-                SessionRow::Header { group, count } => {
+                SessionRow::Header { group, count, .. } => {
                     Some(format!("{}:{}", group.as_deref().unwrap_or("none"), count))
                 }
                 SessionRow::Session { .. } => None,
@@ -896,9 +987,80 @@ mod tests {
         let state = state_with(&["a", "b"], &[("a", "work")]);
         let rows = state.session_rows();
         let has_ungrouped_header = rows.iter().any(|r| {
-            matches!(r, SessionRow::Header { group: None, count } if *count == 1)
+            matches!(r, SessionRow::Header { group: None, count, .. } if *count == 1)
         });
         assert!(has_ungrouped_header);
+    }
+
+    #[test]
+    fn folding_hides_members_but_keeps_header() {
+        // work: a, c ; play: b. Select "a" (in work) and fold its group.
+        let mut state = state_with(
+            &["a", "b", "c"],
+            &[("a", "work"), ("c", "work"), ("b", "play")],
+        );
+        let work_idx = state.sessions.iter().position(|s| s.name == "a").unwrap();
+        state.selected_session = work_idx;
+        state.toggle_fold_current_group();
+
+        let rows = state.session_rows();
+        // No "work" member sessions remain visible, but its header stays
+        // (now marked collapsed); play's member is still shown.
+        let work_collapsed = rows.iter().any(|r| matches!(
+            r,
+            SessionRow::Header { group: Some(g), collapsed: true, .. } if g == "work"
+        ));
+        assert!(work_collapsed);
+        let visible_sessions: Vec<&str> = rows
+            .iter()
+            .filter_map(|r| match r {
+                SessionRow::Session { index } => Some(state.sessions[*index].name.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(visible_sessions, vec!["b"]);
+        // Selection was relocated out of the folded group onto a visible one.
+        assert!(state.session_visible(state.selected_session));
+
+        // Folding again (after selecting back into work) toggles it open.
+        state.toggle_fold_current_group(); // currently on "b" (play) -> folds play
+        // Re-expand work by selecting a work session is impossible while folded;
+        // instead toggle work directly via its key state:
+        state.collapsed_groups.remove(&Some("work".to_string()));
+        let rows = state.session_rows();
+        let names: Vec<&str> = rows
+            .iter()
+            .filter_map(|r| match r {
+                SessionRow::Session { index } => Some(state.sessions[*index].name.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert!(names.contains(&"a") && names.contains(&"c"));
+    }
+
+    #[test]
+    fn navigation_skips_folded_sessions() {
+        let mut state = state_with(
+            &["a", "b", "c"],
+            &[("a", "work"), ("c", "work"), ("b", "play")],
+        );
+        // Order is play(b), work(a,c). Fold work.
+        state.selected_session = state.sessions.iter().position(|s| s.name == "a").unwrap();
+        state.toggle_fold_current_group();
+        // Start on the only visible session "b" and move down: nowhere visible.
+        state.selected_session = state.sessions.iter().position(|s| s.name == "b").unwrap();
+        state.tree_move_down();
+        assert_eq!(state.sessions[state.selected_session].name, "b");
+    }
+
+    #[test]
+    fn fold_is_noop_without_groups() {
+        let mut state = state_with(&["a", "b"], &[]);
+        state.toggle_fold_current_group();
+        let rows = state.session_rows();
+        // No headers, all sessions still visible.
+        assert_eq!(rows.len(), 2);
+        assert!(rows.iter().all(|r| matches!(r, SessionRow::Session { .. })));
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,6 +4,12 @@ use ansi_to_tui::IntoText;
 use ratatui::text::Text;
 use ratatui::widgets::ListState;
 
+use crate::group::GroupStore;
+
+/// Label shown for the implicit group of sessions that have not been assigned
+/// to any user group. Only rendered when at least one session *is* grouped.
+pub const UNGROUPED_LABEL: &str = "Ungrouped";
+
 // =============================================================================
 // Data Structures
 // =============================================================================
@@ -57,6 +63,10 @@ pub struct TmuxSession {
     /// the list without re-querying tmux.
     pub last_attached: i64,
     pub activity: i64,
+    /// tmux-deck-side group label this session belongs to, if any. This is a
+    /// purely organisational tag managed by the deck (see [`crate::group`]),
+    /// independent of tmux's native session groups. `None` means ungrouped.
+    pub group: Option<String>,
 }
 
 // =============================================================================
@@ -220,6 +230,21 @@ pub enum PopupMode {
     RenameSession,
     /// Confirming session kill
     ConfirmKill,
+    /// Assigning the selected session to a tmux-deck group
+    GroupSession,
+}
+
+/// A single rendered row in the Sessions list. Grouping inserts non-selectable
+/// [`SessionRow::Header`] rows between the [`SessionRow::Session`] rows; the
+/// session rows still map 1:1 onto indices into [`UIState::sessions`], so all
+/// navigation continues to operate on session indices and only rendering needs
+/// to be group-aware.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SessionRow {
+    /// A group heading. `group` is `None` for the implicit ungrouped bucket.
+    Header { group: Option<String>, count: usize },
+    /// A session, identified by its index into [`UIState::sessions`].
+    Session { index: usize },
 }
 
 // =============================================================================
@@ -243,6 +268,9 @@ pub struct UIState {
     pub window_list_state: ListState,
     pub pane_list_state: ListState,
     pub session_sort: SessionSort,
+
+    /// Persisted tmux-deck-side session grouping (session name -> group).
+    pub groups: GroupStore,
 
     // MultiPreview state (session_idx, window_idx)
     pub multi_session: usize,
@@ -278,6 +306,8 @@ impl UIState {
             window_list_state: ListState::default(),
             pane_list_state: ListState::default(),
             session_sort: SessionSort::default(),
+
+            groups: GroupStore::load(),
 
             multi_session: 0,
             multi_window: 0,
@@ -435,6 +465,15 @@ impl UIState {
         }
     }
 
+    pub fn open_group_session_popup(&mut self) {
+        if let Some(session) = self.sessions.get(self.selected_session) {
+            self.popup_mode = Some(PopupMode::GroupSession);
+            // Prefill with the current group so editing/clearing is natural.
+            self.input_buffer = session.group.clone().unwrap_or_default();
+            self.input_cursor = self.input_buffer.len();
+        }
+    }
+
     pub fn open_kill_session_popup(&mut self) {
         if !self.sessions.is_empty() {
             self.popup_mode = Some(PopupMode::ConfirmKill);
@@ -469,6 +508,17 @@ impl UIState {
             .map(|s| (s.name.clone(), new_name))
     }
 
+    /// Get the group name typed in the GroupSession popup. An empty/whitespace
+    /// entry means "remove from any group" and is returned as `None`.
+    pub fn get_group_session_input(&self) -> Option<String> {
+        let trimmed = self.input_buffer.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    }
+
     /// Get the session name to kill (for ConfirmKill popup)
     pub fn get_kill_session_name(&self) -> Option<String> {
         if self.confirm_yes_selected {
@@ -494,7 +544,8 @@ impl UIState {
             .map(|s| s.name.clone());
 
         self.sessions = sessions;
-        self.session_sort.apply(&mut self.sessions);
+        self.apply_group_labels();
+        self.order_sessions();
 
         if let Some(name) = current_name
             && let Some(idx) = self.sessions.iter().position(|s| s.name == name)
@@ -504,6 +555,67 @@ impl UIState {
 
         self.validate_selections();
         self.last_error = None;
+    }
+
+    /// Stamp each session with its persisted group label. Called whenever fresh
+    /// session data arrives from tmux, since the tmux layer is group-agnostic.
+    fn apply_group_labels(&mut self) {
+        for session in &mut self.sessions {
+            session.group = self.groups.group_of(&session.name);
+        }
+    }
+
+    /// Order the session list: first by the active [`SessionSort`], then cluster
+    /// sessions of the same group together. Because the clustering pass is a
+    /// *stable* sort keyed only on the group, sessions keep their sort order
+    /// within each group, and ungrouped sessions fall to the bottom.
+    fn order_sessions(&mut self) {
+        self.session_sort.apply(&mut self.sessions);
+        self.sessions.sort_by(|a, b| match (&a.group, &b.group) {
+            (Some(x), Some(y)) => x.to_lowercase().cmp(&y.to_lowercase()),
+            (Some(_), None) => std::cmp::Ordering::Less,
+            (None, Some(_)) => std::cmp::Ordering::Greater,
+            (None, None) => std::cmp::Ordering::Equal,
+        });
+    }
+
+    /// Assign the currently-selected session to `group` (or remove it from any
+    /// group when `group` is `None`/empty), persist the change, and re-order the
+    /// list in place keeping that session highlighted. No tmux round-trip is
+    /// needed — grouping is entirely tmux-deck-side.
+    pub fn assign_selected_group(&mut self, group: Option<String>) {
+        let Some(session) = self.sessions.get(self.selected_session) else {
+            return;
+        };
+        let name = session.name.clone();
+        self.groups.set(&name, group.as_deref());
+        self.apply_group_labels();
+        self.resort_sessions_preserve_selection();
+    }
+
+    /// Build the rendered Sessions rows, inserting group headers. When no
+    /// session is grouped the result is a flat list of [`SessionRow::Session`]
+    /// rows (no headers), matching the pre-grouping behaviour exactly.
+    pub fn session_rows(&self) -> Vec<SessionRow> {
+        let any_grouped = self.sessions.iter().any(|s| s.group.is_some());
+        let mut rows = Vec::with_capacity(self.sessions.len());
+        let mut current: Option<&Option<String>> = None;
+        for (index, session) in self.sessions.iter().enumerate() {
+            if any_grouped && current != Some(&session.group) {
+                let count = self
+                    .sessions
+                    .iter()
+                    .filter(|s| s.group == session.group)
+                    .count();
+                rows.push(SessionRow::Header {
+                    group: session.group.clone(),
+                    count,
+                });
+                current = Some(&session.group);
+            }
+            rows.push(SessionRow::Session { index });
+        }
+        rows
     }
 
     /// Advance to the next [`SessionSort`] and re-sort the list in place,
@@ -519,7 +631,7 @@ impl UIState {
             .get(self.selected_session)
             .map(|s| s.name.clone());
 
-        self.session_sort.apply(&mut self.sessions);
+        self.order_sessions();
 
         if let Some(name) = current_name
             && let Some(idx) = self.sessions.iter().position(|s| s.name == name)
@@ -711,5 +823,94 @@ impl UIState {
         {
             self.multi_window += 1;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn session(name: &str) -> TmuxSession {
+        TmuxSession {
+            name: name.to_string(),
+            attached: false,
+            unread: false,
+            windows: Vec::new(),
+            has_claude: false,
+            last_attached: 0,
+            activity: 0,
+            group: None,
+        }
+    }
+
+    /// Build a UIState with an in-memory (no-disk) group store and the given
+    /// assignments, then load `names` as the session list.
+    fn state_with(names: &[&str], groups: &[(&str, &str)]) -> UIState {
+        let mut state = UIState::new(100);
+        state.groups = GroupStore::default();
+        for (sess, grp) in groups {
+            state.groups.set(sess, Some(grp));
+        }
+        state.update_sessions(names.iter().map(|n| session(n)).collect());
+        state
+    }
+
+    #[test]
+    fn ungrouped_sessions_have_no_headers() {
+        let state = state_with(&["a", "b", "c"], &[]);
+        let rows = state.session_rows();
+        assert_eq!(rows.len(), 3);
+        assert!(rows.iter().all(|r| matches!(r, SessionRow::Session { .. })));
+    }
+
+    #[test]
+    fn grouped_sessions_cluster_with_ungrouped_last() {
+        // a, c -> "work"; b ungrouped. Names tie-break ascending within a group.
+        let state = state_with(&["a", "b", "c"], &[("a", "work"), ("c", "work")]);
+        let ordered: Vec<&str> = state.sessions.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(ordered, vec!["a", "c", "b"]);
+    }
+
+    #[test]
+    fn rows_insert_one_header_per_group() {
+        let state = state_with(
+            &["a", "b", "c"],
+            &[("a", "work"), ("c", "work"), ("b", "play")],
+        );
+        let rows = state.session_rows();
+        // play(b) sorts before work(a,c) alphabetically; ungrouped bucket absent.
+        let labels: Vec<String> = rows
+            .iter()
+            .filter_map(|r| match r {
+                SessionRow::Header { group, count } => {
+                    Some(format!("{}:{}", group.as_deref().unwrap_or("none"), count))
+                }
+                SessionRow::Session { .. } => None,
+            })
+            .collect();
+        assert_eq!(labels, vec!["play:1".to_string(), "work:2".to_string()]);
+    }
+
+    #[test]
+    fn ungrouped_bucket_gets_a_header_when_mixed() {
+        let state = state_with(&["a", "b"], &[("a", "work")]);
+        let rows = state.session_rows();
+        let has_ungrouped_header = rows.iter().any(|r| {
+            matches!(r, SessionRow::Header { group: None, count } if *count == 1)
+        });
+        assert!(has_ungrouped_header);
+    }
+
+    #[test]
+    fn assigning_group_updates_store_and_order() {
+        let mut state = state_with(&["a", "b"], &[]);
+        state.selected_session = 1; // "b"
+        state.assign_selected_group(Some("work".to_string()));
+        assert_eq!(state.groups.group_of("b"), Some("work".to_string()));
+        // "b" is now grouped and clusters above the ungrouped "a".
+        let ordered: Vec<&str> = state.sessions.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(ordered, vec!["b", "a"]);
+        // Selection still tracks "b" after the reorder.
+        assert_eq!(state.sessions[state.selected_session].name, "b");
     }
 }

--- a/src/group.rs
+++ b/src/group.rs
@@ -61,6 +61,21 @@ impl GroupStore {
         self.assignments.get(session).cloned()
     }
 
+    /// All distinct group names currently in use, sorted alphabetically. Used
+    /// to populate the group selection popup so the user can pick an existing
+    /// group rather than retyping its name.
+    pub fn group_names(&self) -> Vec<String> {
+        let mut names: Vec<String> = self
+            .assignments
+            .values()
+            .cloned()
+            .collect::<std::collections::HashSet<_>>()
+            .into_iter()
+            .collect();
+        names.sort();
+        names
+    }
+
     /// Assign `session` to `group`, or remove it from any group when `group`
     /// is `None` or empty. Persists immediately (best effort).
     pub fn set(&mut self, session: &str, group: Option<&str>) {

--- a/src/group.rs
+++ b/src/group.rs
@@ -1,0 +1,157 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use directories::ProjectDirs;
+use tracing::{debug, warn};
+
+// =============================================================================
+// GroupStore — tmux-deck-side session grouping
+// =============================================================================
+//
+// Grouping is a tmux-deck concept, not a tmux one: tmux has its own "session
+// groups" (shared windows), but here a group is purely an organisational label
+// the user attaches to a session inside the deck. The mapping
+// `session_name -> group_name` is persisted to a small TSV file in the user's
+// config directory so groups survive restarts.
+//
+// The file format is intentionally trivial (one `session\tgroup` pair per line)
+// to avoid pulling in a serialization dependency — tmux-deck ships as a single
+// binary with no runtime dependencies and we keep it that way.
+
+#[derive(Debug, Default)]
+pub struct GroupStore {
+    /// session name -> group name
+    assignments: HashMap<String, String>,
+    /// Where the store is persisted. `None` when no config dir could be
+    /// resolved; the store then behaves as an in-memory-only best effort.
+    path: Option<PathBuf>,
+}
+
+impl GroupStore {
+    /// Load the store from the user's config directory. Missing or unreadable
+    /// files yield an empty store — grouping is best-effort and must never
+    /// prevent the app from starting.
+    pub fn load() -> Self {
+        let path = Self::default_path();
+        let mut assignments = HashMap::new();
+        if let Some(p) = path.as_ref()
+            && let Ok(contents) = std::fs::read_to_string(p)
+        {
+            for line in contents.lines() {
+                if let Some((session, group)) = line.split_once('\t') {
+                    let session = session.trim();
+                    let group = group.trim();
+                    if !session.is_empty() && !group.is_empty() {
+                        assignments.insert(session.to_string(), group.to_string());
+                    }
+                }
+            }
+            debug!("loaded {} group assignment(s)", assignments.len());
+        }
+        Self { assignments, path }
+    }
+
+    fn default_path() -> Option<PathBuf> {
+        let dirs = ProjectDirs::from("dev", "tkcd", "tmux-deck")?;
+        Some(dirs.config_dir().join("groups.tsv"))
+    }
+
+    /// Group a session belongs to, if any.
+    pub fn group_of(&self, session: &str) -> Option<String> {
+        self.assignments.get(session).cloned()
+    }
+
+    /// Assign `session` to `group`, or remove it from any group when `group`
+    /// is `None` or empty. Persists immediately (best effort).
+    pub fn set(&mut self, session: &str, group: Option<&str>) {
+        match group.map(str::trim).filter(|g| !g.is_empty()) {
+            Some(g) => {
+                self.assignments.insert(session.to_string(), g.to_string());
+            }
+            None => {
+                self.assignments.remove(session);
+            }
+        }
+        self.save();
+    }
+
+    /// Carry a session's group across a rename so the assignment is not lost
+    /// when the underlying tmux session changes name.
+    pub fn rename_session(&mut self, old_name: &str, new_name: &str) {
+        if let Some(group) = self.assignments.remove(old_name) {
+            self.assignments.insert(new_name.to_string(), group);
+            self.save();
+        }
+    }
+
+    /// Drop a killed session's assignment so the store does not accumulate
+    /// entries for sessions that no longer exist.
+    pub fn forget(&mut self, session: &str) {
+        if self.assignments.remove(session).is_some() {
+            self.save();
+        }
+    }
+
+    fn save(&self) {
+        let Some(path) = self.path.as_ref() else {
+            return;
+        };
+        if let Some(parent) = path.parent()
+            && let Err(e) = std::fs::create_dir_all(parent)
+        {
+            warn!("failed to create config dir for group store: {e}");
+            return;
+        }
+        // Tabs/newlines in a session name would corrupt the line format; tmux
+        // session names cannot contain them in practice, but guard anyway.
+        let mut out = String::new();
+        for (session, group) in &self.assignments {
+            if session.contains(['\t', '\n']) || group.contains(['\t', '\n']) {
+                continue;
+            }
+            out.push_str(session);
+            out.push('\t');
+            out.push_str(group);
+            out.push('\n');
+        }
+        if let Err(e) = std::fs::write(path, out) {
+            warn!("failed to write group store: {e}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn set_and_query() {
+        let mut store = GroupStore::default();
+        assert_eq!(store.group_of("a"), None);
+        store.set("a", Some("work"));
+        assert_eq!(store.group_of("a"), Some("work".to_string()));
+        // Empty / whitespace group removes the assignment.
+        store.set("a", Some("  "));
+        assert_eq!(store.group_of("a"), None);
+        store.set("a", Some("work"));
+        store.set("a", None);
+        assert_eq!(store.group_of("a"), None);
+    }
+
+    #[test]
+    fn rename_preserves_group() {
+        let mut store = GroupStore::default();
+        store.set("old", Some("work"));
+        store.rename_session("old", "new");
+        assert_eq!(store.group_of("old"), None);
+        assert_eq!(store.group_of("new"), Some("work".to_string()));
+    }
+
+    #[test]
+    fn forget_removes() {
+        let mut store = GroupStore::default();
+        store.set("a", Some("work"));
+        store.forget("a");
+        assert_eq!(store.group_of("a"), None);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod actor;
 mod app;
 mod cli;
+mod group;
 mod ui;
 
 use std::io;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,6 +1,6 @@
 use ratatui::{
     prelude::*,
-    widgets::{Block, Borders, Clear, List, ListItem, Paragraph, Wrap},
+    widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap},
 };
 
 use crate::app::{
@@ -85,12 +85,10 @@ pub fn render_ui(frame: &mut Frame, state: &mut UIState) {
         match popup_mode {
             PopupMode::NewSession => render_session_name_popup(frame, state, "New Session", "Enter session name:"),
             PopupMode::RenameSession => render_session_name_popup(frame, state, "Rename Session", "Enter new name:"),
-            PopupMode::GroupSession => render_session_name_popup(
-                frame,
-                state,
-                "Group Session",
-                "Group name (empty to ungroup):",
-            ),
+            PopupMode::GroupSession => render_group_select_popup(frame, state),
+            PopupMode::NewGroup => {
+                render_session_name_popup(frame, state, "New Group", "New group name:")
+            }
             PopupMode::ConfirmKill => render_confirm_kill_popup(frame, state),
         }
     }
@@ -735,6 +733,73 @@ fn render_session_name_popup(frame: &mut Frame, state: &UIState, title: &str, la
         .wrap(Wrap { trim: false });
 
     frame.render_widget(input_paragraph, input_area);
+}
+
+/// Render the group selection list: every existing group, then an "Ungrouped"
+/// entry that clears the assignment and a "New group" entry that switches to
+/// text entry. The highlighted row tracks [`UIState::group_choice_index`].
+fn render_group_select_popup(frame: &mut Frame, state: &UIState) {
+    let area = frame.area();
+
+    let session_name = state
+        .sessions
+        .get(state.selected_session)
+        .map(|s| s.name.as_str())
+        .unwrap_or("");
+
+    // Build the rows in the same order the selection index walks them.
+    let mut items: Vec<ListItem> = Vec::new();
+    for group in &state.group_choices {
+        items.push(ListItem::new(Line::from(group.clone())));
+    }
+    let ungrouped_label = "(Ungrouped)";
+    items.push(ListItem::new(Line::from(Span::styled(
+        ungrouped_label,
+        Style::default().fg(Color::DarkGray),
+    ))));
+    items.push(ListItem::new(Line::from(Span::styled(
+        "+ New group…",
+        Style::default().fg(Color::Green),
+    ))));
+
+    // Size the popup to the content, clamped so it always fits on screen.
+    let list_len = items.len() as u16;
+    let popup_width = (area.width * 60 / 100).clamp(40, 70);
+    let max_height = area.height.saturating_sub(2).max(5);
+    let popup_height = (list_len + 4).min(max_height);
+
+    let popup_x = (area.width.saturating_sub(popup_width)) / 2;
+    let popup_y = (area.height.saturating_sub(popup_height)) / 2;
+
+    let popup_area = Rect {
+        x: popup_x,
+        y: popup_y,
+        width: popup_width,
+        height: popup_height,
+    };
+
+    frame.render_widget(Clear, popup_area);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan))
+        .title(format!(" Group: {} ", session_name))
+        .title_bottom(Line::from(" ↑↓:select | Enter:confirm | Esc:cancel ").centered());
+
+    let inner = block.inner(popup_area);
+    frame.render_widget(block, popup_area);
+
+    let mut list_state = ListState::default();
+    list_state.select(Some(state.group_choice_index.min(items.len().saturating_sub(1))));
+
+    let list = List::new(items).highlight_style(
+        Style::default()
+            .bg(Color::Cyan)
+            .fg(Color::Black)
+            .add_modifier(Modifier::BOLD),
+    );
+
+    frame.render_stateful_widget(list, inner, &mut list_state);
 }
 
 fn render_confirm_kill_popup(frame: &mut Frame, state: &UIState) {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -98,10 +98,15 @@ fn render_sessions_list(frame: &mut Frame, state: &mut UIState, area: Rect) {
     let mut selected_row: Option<usize> = None;
     for (row_idx, row) in rows.iter().enumerate() {
         match row {
-            SessionRow::Header { group, count } => {
+            SessionRow::Header {
+                group,
+                count,
+                collapsed,
+            } => {
                 let label = group.as_deref().unwrap_or(UNGROUPED_LABEL);
+                let arrow = if *collapsed { '▸' } else { '▾' };
                 items.push(ListItem::new(Line::from(vec![Span::styled(
-                    format!("▾ {} ({})", label, count),
+                    format!("{} {} ({})", arrow, label, count),
                     Style::default()
                         .fg(Color::Cyan)
                         .add_modifier(Modifier::BOLD),
@@ -328,6 +333,8 @@ fn render_tree_status_bar(frame: &mut Frame, state: &UIState, area: Rect) {
             Span::raw(":sort "),
             Span::styled("g", Style::default().fg(Color::Yellow)),
             Span::raw(":group "),
+            Span::styled("za", Style::default().fg(Color::Yellow)),
+            Span::raw(":fold "),
             Span::styled("Space×2", Style::default().fg(Color::Magenta)),
             Span::raw(":multi "),
             Span::styled("C-n", Style::default().fg(Color::Green)),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -96,6 +96,16 @@ fn render_sessions_list(frame: &mut Frame, state: &mut UIState, area: Rect) {
 
     let mut items: Vec<ListItem> = Vec::with_capacity(rows.len());
     let mut selected_row: Option<usize> = None;
+    // When the selection sits on a folded group, the cursor lands on that
+    // group's header instead of a (hidden) member session.
+    let selected_group = if state.selection_on_folded_header() {
+        state
+            .sessions
+            .get(state.selected_session)
+            .map(|s| s.group.clone())
+    } else {
+        None
+    };
     for (row_idx, row) in rows.iter().enumerate() {
         match row {
             SessionRow::Header {
@@ -105,11 +115,19 @@ fn render_sessions_list(frame: &mut Frame, state: &mut UIState, area: Rect) {
             } => {
                 let label = group.as_deref().unwrap_or(UNGROUPED_LABEL);
                 let arrow = if *collapsed { '▸' } else { '▾' };
+                let is_selected = selected_group.as_ref() == Some(group);
+                if is_selected {
+                    selected_row = Some(row_idx);
+                }
+                let mut style = Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD);
+                if is_selected {
+                    style = style.bg(Color::DarkGray).fg(Color::White);
+                }
                 items.push(ListItem::new(Line::from(vec![Span::styled(
                     format!("{} {} ({})", arrow, label, count),
-                    Style::default()
-                        .fg(Color::Cyan)
-                        .add_modifier(Modifier::BOLD),
+                    style,
                 )])));
             }
             SessionRow::Session { index } => {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -3,7 +3,10 @@ use ratatui::{
     widgets::{Block, Borders, Clear, List, ListItem, Paragraph, Wrap},
 };
 
-use crate::app::{Focus, InputMode, PopupMode, TmuxPane, TmuxWindow, UIState, ViewMode};
+use crate::app::{
+    Focus, InputMode, PopupMode, SessionRow, TmuxPane, TmuxWindow, UIState, UNGROUPED_LABEL,
+    ViewMode,
+};
 
 /// Orange color used to flag sessions / windows / panes that have a claude
 /// process running. Color::Indexed(208) is the standard 256-color "Orange1"
@@ -32,6 +35,12 @@ pub fn render_ui(frame: &mut Frame, state: &mut UIState) {
         match popup_mode {
             PopupMode::NewSession => render_session_name_popup(frame, state, "New Session", "Enter session name:"),
             PopupMode::RenameSession => render_session_name_popup(frame, state, "Rename Session", "Enter new name:"),
+            PopupMode::GroupSession => render_session_name_popup(
+                frame,
+                state,
+                "Group Session",
+                "Group name (empty to ungroup):",
+            ),
             PopupMode::ConfirmKill => render_confirm_kill_popup(frame, state),
         }
     }
@@ -77,31 +86,62 @@ fn render_sessions_list(frame: &mut Frame, state: &mut UIState, area: Rect) {
         Style::default().fg(Color::DarkGray)
     };
 
-    let items: Vec<ListItem> = state
-        .sessions
+    // Grouping turns the flat session list into a list of rows that may also
+    // contain non-selectable group headers. When nothing is grouped, the rows
+    // are all sessions and this renders identically to the ungrouped list.
+    let rows = state.session_rows();
+    let indented = rows
         .iter()
-        .enumerate()
-        .map(|(i, session)| {
-            let style = if i == state.selected_session {
-                Style::default().bg(Color::DarkGray).fg(Color::White)
-            } else {
-                Style::default()
-            };
-            let mut spans = vec![Span::raw(session.name.clone())];
-            if session.attached {
-                spans.push(Span::styled(" ●", Style::default().fg(Color::Green)));
-            } else if session.unread {
-                spans.push(Span::styled(" ◆", Style::default().fg(Color::Yellow)));
+        .any(|r| matches!(r, SessionRow::Header { .. }));
+
+    let mut items: Vec<ListItem> = Vec::with_capacity(rows.len());
+    let mut selected_row: Option<usize> = None;
+    for (row_idx, row) in rows.iter().enumerate() {
+        match row {
+            SessionRow::Header { group, count } => {
+                let label = group.as_deref().unwrap_or(UNGROUPED_LABEL);
+                items.push(ListItem::new(Line::from(vec![Span::styled(
+                    format!("▾ {} ({})", label, count),
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD),
+                )])));
             }
-            if session.has_claude {
-                spans.push(Span::styled(
-                    format!(" {}", CLAUDE_MARKER),
-                    Style::default().fg(CLAUDE_MARKER_COLOR),
-                ));
+            SessionRow::Session { index } => {
+                let session = &state.sessions[*index];
+                if *index == state.selected_session {
+                    selected_row = Some(row_idx);
+                }
+                let style = if *index == state.selected_session {
+                    Style::default().bg(Color::DarkGray).fg(Color::White)
+                } else {
+                    Style::default()
+                };
+                // Indent sessions under their header so the hierarchy reads.
+                let mut spans = vec![Span::raw(if indented {
+                    format!("  {}", session.name)
+                } else {
+                    session.name.clone()
+                })];
+                if session.attached {
+                    spans.push(Span::styled(" ●", Style::default().fg(Color::Green)));
+                } else if session.unread {
+                    spans.push(Span::styled(" ◆", Style::default().fg(Color::Yellow)));
+                }
+                if session.has_claude {
+                    spans.push(Span::styled(
+                        format!(" {}", CLAUDE_MARKER),
+                        Style::default().fg(CLAUDE_MARKER_COLOR),
+                    ));
+                }
+                items.push(ListItem::new(Line::from(spans)).style(style));
             }
-            ListItem::new(Line::from(spans)).style(style)
-        })
-        .collect();
+        }
+    }
+
+    // The highlight tracks rendered rows, not session indices, so map the
+    // selected session onto its row before handing the state to ratatui.
+    state.session_list_state.select(selected_row);
 
     let list = List::new(items)
         .block(
@@ -286,6 +326,8 @@ fn render_tree_status_bar(frame: &mut Frame, state: &UIState, area: Rect) {
             Span::raw(":focus "),
             Span::styled("s", Style::default().fg(Color::Yellow)),
             Span::raw(":sort "),
+            Span::styled("g", Style::default().fg(Color::Yellow)),
+            Span::raw(":group "),
             Span::styled("Space×2", Style::default().fg(Color::Magenta)),
             Span::raw(":multi "),
             Span::styled("C-n", Style::default().fg(Color::Green)),


### PR DESCRIPTION
## 概要

TreeView のセッションを tmux-deck 側のラベルでグループ分けする機能です。tmux ネイティブのセッショングループとは独立した、deck 内の整理用ラベルです。

直近の追加として、`g` キーでのグループ割り当て時に **既存グループを選択リストから選べる** ようにしました。

## 機能

- `g` でグループ選択ポップアップを開く
  - 既存グループ一覧 + `(Ungrouped)`(グループ解除)+ `+ New group…`(新規作成)を表示
  - `↑↓` / `j`・`k` で選択、`Enter` で確定
  - `+ New group…` を選ぶとテキスト入力に切り替わり新規グループ名を作成
  - 現在のグループ(未所属なら `(Ungrouped)`)が初期ハイライト
- `za` でグループの折りたたみ/展開
- グループは TSV ファイルに永続化され再起動後も維持
- セッションのリネーム/削除時にグループ割り当てを追従・破棄

## テスト

- `cargo build` / `cargo test`(22件)/ `cargo clippy` すべてパス
- グループ一覧取得・初期ハイライト・ナビゲーションのラップ動作のテストを追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)