### PR TITLE
fix: ポップアップの日本語入力パニックとカーソル・入力欄の不具合修正

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1011,7 +1011,7 @@ dependencies = [
 
 [[package]]
 name = "tmux-deck"
-version = "0.1.10"
+version = "0.0.0"
 dependencies = [
  "ansi-to-tui",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tmux-deck"
-version = "0.1.10"
+version = "0.0.0"
 edition = "2024"
 authors = ["tkcd <goriponikeike55@gmail.com>"]
 repository = "https://github.com/takeshid/tmux-deck"

--- a/src/actor/ui_actor.rs
+++ b/src/actor/ui_actor.rs
@@ -8,7 +8,9 @@ use ratatui::backend::CrosstermBackend;
 use tokio::sync::{mpsc, oneshot};
 
 use crate::actor::messages::{RefreshControl, TmuxCommand, TmuxResponse, UIEvent};
-use crate::app::{Focus, GroupChoice, InputMode, PopupMode, UIState, ViewMode};
+use crate::app::{
+    Focus, GroupChoice, InputMode, PopupMode, SESSION_NAME_MAX_LEN, UIState, ViewMode,
+};
 use crate::ui::render_ui;
 
 // =============================================================================
@@ -255,7 +257,9 @@ impl UIActor {
                     KeyCode::Right => self.state.input_move_right(),
                     KeyCode::Home => self.state.input_move_home(),
                     KeyCode::End => self.state.input_move_end(),
-                    KeyCode::Char(c) => self.state.input_char(c),
+                    KeyCode::Char(c) => {
+                        self.state.input_char_limited(c, SESSION_NAME_MAX_LEN)
+                    }
                     _ => {}
                 }
             }

--- a/src/app.rs
+++ b/src/app.rs
@@ -11,6 +11,10 @@ use crate::group::GroupStore;
 /// to any user group. Only rendered when at least one session *is* grouped.
 pub const UNGROUPED_LABEL: &str = "Ungrouped";
 
+/// Maximum number of characters (not bytes) accepted in the session/group name
+/// input popups. Keeps names short enough to render in the narrow list panes.
+pub const SESSION_NAME_MAX_LEN: usize = 30;
+
 // =============================================================================
 // Data Structures
 // =============================================================================
@@ -560,6 +564,15 @@ impl UIState {
         let byte_offset = self.input_cursor_byte_offset();
         self.input_buffer.insert(byte_offset, c);
         self.input_cursor += 1;
+    }
+
+    /// Insert a character only while the buffer holds fewer than `max_chars`
+    /// characters; otherwise the keystroke is ignored. Used by the session/group
+    /// name popups to cap the name length.
+    pub fn input_char_limited(&mut self, c: char, max_chars: usize) {
+        if self.input_char_count() < max_chars {
+            self.input_char(c);
+        }
     }
 
     pub fn input_backspace(&mut self) {
@@ -1371,5 +1384,24 @@ mod tests {
         assert_eq!(state.input_cursor, 0);
         state.input_move_end();
         assert_eq!(state.input_cursor, 2);
+    }
+
+    #[test]
+    fn input_char_limited_caps_char_count() {
+        let mut state = UIState::new(100);
+        for _ in 0..40 {
+            state.input_char_limited('a', SESSION_NAME_MAX_LEN);
+        }
+        assert_eq!(state.input_buffer.chars().count(), SESSION_NAME_MAX_LEN);
+    }
+
+    #[test]
+    fn input_char_limited_counts_chars_not_bytes() {
+        let mut state = UIState::new(100);
+        // マルチバイト文字でもバイト長ではなく文字数で制限される
+        for _ in 0..40 {
+            state.input_char_limited('あ', SESSION_NAME_MAX_LEN);
+        }
+        assert_eq!(state.input_buffer.chars().count(), SESSION_NAME_MAX_LEN);
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -542,21 +542,38 @@ impl UIState {
         }
     }
 
+    /// `input_cursor`（char 単位）を `input_buffer` 内のバイトオフセットへ変換する。
+    fn input_cursor_byte_offset(&self) -> usize {
+        self.input_buffer
+            .char_indices()
+            .nth(self.input_cursor)
+            .map(|(byte_idx, _)| byte_idx)
+            .unwrap_or(self.input_buffer.len())
+    }
+
+    /// `input_buffer` の文字数（char 単位）。
+    fn input_char_count(&self) -> usize {
+        self.input_buffer.chars().count()
+    }
+
     pub fn input_char(&mut self, c: char) {
-        self.input_buffer.insert(self.input_cursor, c);
+        let byte_offset = self.input_cursor_byte_offset();
+        self.input_buffer.insert(byte_offset, c);
         self.input_cursor += 1;
     }
 
     pub fn input_backspace(&mut self) {
         if self.input_cursor > 0 {
             self.input_cursor -= 1;
-            self.input_buffer.remove(self.input_cursor);
+            let byte_offset = self.input_cursor_byte_offset();
+            self.input_buffer.remove(byte_offset);
         }
     }
 
     pub fn input_delete(&mut self) {
-        if self.input_cursor < self.input_buffer.len() {
-            self.input_buffer.remove(self.input_cursor);
+        if self.input_cursor < self.input_char_count() {
+            let byte_offset = self.input_cursor_byte_offset();
+            self.input_buffer.remove(byte_offset);
         }
     }
 
@@ -567,7 +584,7 @@ impl UIState {
     }
 
     pub fn input_move_right(&mut self) {
-        if self.input_cursor < self.input_buffer.len() {
+        if self.input_cursor < self.input_char_count() {
             self.input_cursor += 1;
         }
     }
@@ -577,7 +594,7 @@ impl UIState {
     }
 
     pub fn input_move_end(&mut self) {
-        self.input_cursor = self.input_buffer.len();
+        self.input_cursor = self.input_char_count();
     }
 
     // =========================================================================
@@ -594,7 +611,7 @@ impl UIState {
         if let Some(session) = self.sessions.get(self.selected_session) {
             self.popup_mode = Some(PopupMode::RenameSession);
             self.input_buffer = session.name.clone();
-            self.input_cursor = self.input_buffer.len();
+            self.input_cursor = self.input_char_count();
         }
     }
 
@@ -1307,5 +1324,52 @@ mod tests {
         );
         state.group_choice_down();
         assert_eq!(state.selected_group_choice(), GroupChoice::Ungrouped);
+    }
+
+    #[test]
+    fn input_handles_multibyte_chars_without_panic() {
+        let mut state = UIState::new(100);
+        // 日本語を複数文字入力（旧実装ではバイト境界パニックしていた）
+        state.input_char('あ');
+        state.input_char('い');
+        state.input_char('う');
+        assert_eq!(state.input_buffer, "あいう");
+        assert_eq!(state.input_cursor, 3);
+    }
+
+    #[test]
+    fn input_cursor_movement_and_editing_with_multibyte() {
+        let mut state = UIState::new(100);
+        for c in "あいう".chars() {
+            state.input_char(c);
+        }
+        // 左へ2つ移動 → カーソルは「い」の前
+        state.input_move_left();
+        state.input_move_left();
+        assert_eq!(state.input_cursor, 1);
+        // カーソル位置に「ん」を挿入
+        state.input_char('ん');
+        assert_eq!(state.input_buffer, "あんいう");
+        assert_eq!(state.input_cursor, 2);
+        // backspace で「ん」を削除
+        state.input_backspace();
+        assert_eq!(state.input_buffer, "あいう");
+        assert_eq!(state.input_cursor, 1);
+        // delete でカーソル位置の「い」を削除
+        state.input_delete();
+        assert_eq!(state.input_buffer, "あう");
+        assert_eq!(state.input_cursor, 1);
+    }
+
+    #[test]
+    fn input_move_end_uses_char_count() {
+        let mut state = UIState::new(100);
+        for c in "あい".chars() {
+            state.input_char(c);
+        }
+        state.input_move_home();
+        assert_eq!(state.input_cursor, 0);
+        state.input_move_end();
+        assert_eq!(state.input_cursor, 2);
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -670,7 +670,9 @@ fn render_input_popup(frame: &mut Frame, state: &UIState, area: Rect) {
 fn render_session_name_popup(frame: &mut Frame, state: &UIState, title: &str, label: &str) {
     let area = frame.area();
     let popup_width = (area.width * 60 / 100).clamp(40, 70);
-    let popup_height = 7;
+    // border(1) + label(1) + input(1) + border(1) = 4 rows: the input field is
+    // a single line tall.
+    let popup_height = 4;
 
     let popup_x = (area.width.saturating_sub(popup_width)) / 2;
     let popup_y = (area.height.saturating_sub(popup_height)) / 2;
@@ -693,17 +695,13 @@ fn render_session_name_popup(frame: &mut Frame, state: &UIState, title: &str, la
     let inner = block.inner(popup_area);
     frame.render_widget(block, popup_area);
 
-    let input_chunks = Layout::vertical([
-        Constraint::Length(1),
-        Constraint::Length(1),
-        Constraint::Min(1),
-    ])
-    .split(inner);
+    let input_chunks =
+        Layout::vertical([Constraint::Length(1), Constraint::Length(1)]).split(inner);
 
     let label_widget = Paragraph::new(label).style(Style::default().fg(Color::White));
     frame.render_widget(label_widget, input_chunks[0]);
 
-    let input_area = input_chunks[2];
+    let input_area = input_chunks[1];
 
     // Render input with cursor
     // input_cursor は char 単位なので、char 単位で前後を分割する

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,6 +1,6 @@
 use ratatui::{
     prelude::*,
-    widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap},
+    widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph},
 };
 
 use crate::app::{
@@ -658,8 +658,7 @@ fn render_input_popup(frame: &mut Frame, state: &UIState, area: Rect) {
     ]);
 
     let input_paragraph = Paragraph::new(input_text)
-        .style(Style::default().fg(Color::White).bg(Color::DarkGray))
-        .wrap(Wrap { trim: false });
+        .style(Style::default().fg(Color::White).bg(Color::DarkGray));
 
     frame.render_widget(input_paragraph, input_area);
 }
@@ -731,8 +730,7 @@ fn render_session_name_popup(frame: &mut Frame, state: &UIState, title: &str, la
     ]);
 
     let input_paragraph = Paragraph::new(input_text)
-        .style(Style::default().fg(Color::White).bg(Color::DarkGray))
-        .wrap(Wrap { trim: false });
+        .style(Style::default().fg(Color::White).bg(Color::DarkGray));
 
     frame.render_widget(input_paragraph, input_area);
 }
@@ -878,4 +876,51 @@ fn render_confirm_kill_popup(frame: &mut Frame, state: &UIState) {
 
     frame.render_widget(yes_button, button_chunks[0]);
     frame.render_widget(no_button, button_chunks[1]);
+}
+
+#[cfg(test)]
+mod cursor_alignment_tests {
+    use super::*;
+    use ratatui::{backend::TestBackend, Terminal};
+
+    /// 白背景（カーソルブロック）のセルの (x, y) を返す。
+    fn cursor_cell(buf: &ratatui::buffer::Buffer) -> Option<(u16, u16)> {
+        for y in 0..buf.area.height {
+            for x in 0..buf.area.width {
+                if buf.cell((x, y)).unwrap().style().bg == Some(Color::White) {
+                    return Some((x, y));
+                }
+            }
+        }
+        None
+    }
+
+    fn render_name_popup_cursor(text: &str) -> Option<(u16, u16)> {
+        let mut state = UIState::new(100);
+        state.popup_mode = Some(PopupMode::NewSession);
+        for c in text.chars() {
+            state.input_char(c);
+        }
+        let mut term = Terminal::new(TestBackend::new(60, 20)).unwrap();
+        term.draw(|f| render_session_name_popup(f, &state, "New Session", "Label:"))
+            .unwrap();
+        cursor_cell(term.backend().buffer())
+    }
+
+    #[test]
+    fn cursor_row_is_stable_between_empty_and_filled() {
+        let empty = render_name_popup_cursor("").expect("cursor visible when empty");
+        let filled = render_name_popup_cursor("abc").expect("cursor visible with text");
+        // 行が一致していること（以前は空文字時に1行下へずれていた）
+        assert_eq!(empty.1, filled.1, "cursor row must not shift");
+        // 空文字時はカーソルが先頭列、文字入力後は文字数ぶん右
+        assert_eq!(filled.0, empty.0 + 3, "cursor should advance by char count");
+    }
+
+    #[test]
+    fn cursor_row_is_stable_with_multibyte() {
+        let empty = render_name_popup_cursor("").expect("cursor visible when empty");
+        let jp = render_name_popup_cursor("あい").expect("cursor visible with text");
+        assert_eq!(empty.1, jp.1, "cursor row must not shift with multibyte input");
+    }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -634,18 +634,19 @@ fn render_input_popup(frame: &mut Frame, state: &UIState, area: Rect) {
 
     let input_area = input_chunks[2];
 
-    let before_cursor = &state.input_buffer[..state.input_cursor];
+    // input_cursor は char 単位なので、char 単位で前後を分割する
+    let before_cursor: String = state.input_buffer.chars().take(state.input_cursor).collect();
     let cursor_char = state
         .input_buffer
         .chars()
         .nth(state.input_cursor)
         .map(|c| c.to_string())
         .unwrap_or_else(|| " ".to_string());
-    let after_cursor = if state.input_cursor < state.input_buffer.len() {
-        &state.input_buffer[state.input_cursor + cursor_char.len()..]
-    } else {
-        ""
-    };
+    let after_cursor: String = state
+        .input_buffer
+        .chars()
+        .skip(state.input_cursor + 1)
+        .collect();
 
     let input_text = Line::from(vec![
         Span::raw(before_cursor),
@@ -706,18 +707,19 @@ fn render_session_name_popup(frame: &mut Frame, state: &UIState, title: &str, la
     let input_area = input_chunks[2];
 
     // Render input with cursor
-    let before_cursor = &state.input_buffer[..state.input_cursor];
+    // input_cursor は char 単位なので、char 単位で前後を分割する
+    let before_cursor: String = state.input_buffer.chars().take(state.input_cursor).collect();
     let cursor_char = state
         .input_buffer
         .chars()
         .nth(state.input_cursor)
         .map(|c| c.to_string())
         .unwrap_or_else(|| " ".to_string());
-    let after_cursor = if state.input_cursor < state.input_buffer.len() {
-        &state.input_buffer[state.input_cursor + cursor_char.len()..]
-    } else {
-        ""
-    };
+    let after_cursor: String = state
+        .input_buffer
+        .chars()
+        .skip(state.input_cursor + 1)
+        .collect();
 
     let input_text = Line::from(vec![
         Span::raw(before_cursor),


### PR DESCRIPTION
## 概要

ポップアップ入力まわりの不具合を修正し、セッション名／グループ名入力フォームの仕様を調整しました。fcitx5 等の IME で日本語を入力すると tmux-deck がパニックする問題が起点です。

## 変更内容

### 1. マルチバイト入力時のパニック修正 (`69c80cf`)
`input_cursor` が char インデックスとバイトインデックスで混在して扱われており、日本語などマルチバイト文字を2文字以上入力すると `String::insert` がバイト境界外を触ってパニックしていました。

- `input_cursor` を一貫して **char インデックス**で扱い、`String` 操作時のみバイトオフセットへ変換
- 描画側（`ui.rs`）のバイトスライスと char インデックスの混在も解消

### 2. カーソル位置のずれ修正 (`13a249a`)
入力欄が `Wrap { trim: false }` で描画されており、`WordWrapper` が「行頭が空白だけの行」を次行へ送り込むため、**空文字時にカーソルブロックが入力行より1行下にずれて**いました。単一行入力フィールドなので wrap を除去。

### 3. 入力欄を1行高に＋30文字制限 (`7c4fb94`)
- New Session / Rename Session / New Group のポップアップ高さを 7→4 に縮め、入力欄を1行高に
- 名前を **30文字（バイト数ではなく文字数）** に制限する `input_char_limited` を追加
- メッセージ入力ポップアップは対象外（従来どおり無制限）

## テスト

`TestBackend` を使ったカーソル位置の実測テストを含め、回帰防止テストを追加。全29テストパス・clippy 警告なしを確認済みです。

- マルチバイト入力でパニックしない
- カーソル移動・挿入・backspace・delete の複合（日本語）
- 空文字／文字ありでカーソル行がずれない
- 文字数制限が char 単位で機能する

🤖 Generated with [Claude Code](https://claude.com/claude-code)