### PR TITLE
feat: XDG TOML configuration (theme, keybindings, hook markers, layout, behavior)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,6 +403,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -419,6 +425,16 @@ name = "indenter"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+]
 
 [[package]]
 name = "indoc"
@@ -512,7 +528,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -785,6 +801,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -818,6 +835,15 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1011,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "tmux-deck"
-version = "0.1.10"
+version = "0.0.0"
 dependencies = [
  "ansi-to-tui",
  "clap",
@@ -1020,8 +1046,10 @@ dependencies = [
  "crossterm",
  "directories",
  "ratatui",
+ "serde",
  "serde_json",
  "tokio",
+ "toml",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1053,6 +1081,47 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tracing"
@@ -1362,6 +1431,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tmux-deck"
-version = "0.1.10"
+version = "0.0.0"
 edition = "2024"
 authors = ["tkcd <goriponikeike55@gmail.com>"]
 repository = "https://github.com/takeshid/tmux-deck"
@@ -20,7 +20,9 @@ clap-cargo = "0.18.3"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter", "local-time"] }
 directories = "6.0.0"
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+toml = "0.8"
 
 [[bin]]
 name = "tmux-deck"

--- a/README.md
+++ b/README.md
@@ -64,6 +64,81 @@ if youde use flake, you can add `tmux-deck` in your flake.nix
 }
 ```
 
+# Configuration
+
+tmux-deck is **zero-config**: it runs with sensible defaults and needs no file.
+To customise it, drop a TOML file at:
+
+```
+$XDG_CONFIG_HOME/tmux-deck/config.toml   # usually ~/.config/tmux-deck/config.toml
+```
+
+(or point at one with `tmux-deck --config <path>`). A missing or malformed file
+just falls back to the defaults, so it can never stop the app from starting. A
+fully-commented template lives at [`docs/config.example.toml`](docs/config.example.toml).
+
+```toml
+[preview]
+interval = 300            # preview refresh interval (ms); --interval overrides this
+
+[theme]
+preset = "default"        # see the table below
+[theme.colors]            # optional per-role overrides on top of the preset
+# accent = "#7dcfff"
+
+[keybindings]             # remap the main actions (chords like `za` are fixed)
+quit           = ["q", "Esc"]
+new_session    = "C-n"
+
+[hooks.claude]            # per-state markers: glyph + colour ("spinner" animates)
+working = { glyph = "spinner", color = "208" }
+waiting = { glyph = "◆", color = "208" }
+
+[layout]
+session_panel_width = 30  # left panel width (%); tree_split / multi_selected_ratio too
+
+[behavior]
+default_view   = "tree"   # "tree" | "multi"
+exit_on_switch = true     # exit after switching to a session
+```
+
+## Themes
+
+Set `theme.preset` to one of:
+
+| Preset | Notes |
+| ------ | ----- |
+| `default` | The original palette (orange markers, cyan/yellow accents). |
+| `monochrome` | Distinguished by brightness, not hue — colour-blind friendly. |
+| `dracula` | |
+| `nord` | |
+| `gruvbox` | |
+| `tokyonight` | |
+| `catppuccin` | Mocha flavour. |
+| `solarized` | Dark variant. |
+| `cyberdream` | |
+| `carbonfox` | |
+
+Colour values are a name (`red`, `darkgray`, `lightblue`…), a 256-colour index
+(`"208"`), or truecolor hex (`"#rrggbb"`).
+
+## Key bindings
+
+The remappable actions and their defaults:
+
+| Action | Default | Action | Default |
+| ------ | ------- | ------ | ------- |
+| `quit` | `q`, `Esc` | `new_session` | `C-n` |
+| `refresh` | `r` | `rename_session` | `C-r` |
+| `sort` | `s` | `kill_session` | `C-x` |
+| `group` | `g` | `enter` | `Enter` |
+| `input` | `i` | | |
+
+A binding is one key string or a list. Modifiers are joined with `-` (`C`/`Ctrl`,
+`S`/`Shift`, `A`/`M`/`Alt`); keys are a single character or a name (`Esc`, `Tab`,
+`Up`, `Space`, …). Navigation (`j/k/h/l`, arrows, Tab) and the `za` fold /
+double-`Space` chords are fixed for now.
+
 # Claude Code Integration
 
 tmux-deck highlights tmux entities that are running [Claude Code](https://code.claude.com).
@@ -157,10 +232,10 @@ Written in Rust for maximum performance and minimal resource usage.
     - [x] Injection command to pane
     - [x] Zoom preview
     - [ ] Pinning
-- [ ] Configure
-    - [ ] Keybinding
-    - [ ] Layout
-    - [ ] Color Theme
+- [x] Configure (TOML, XDG `~/.config/tmux-deck/config.toml`)
+    - [x] Keybinding
+    - [x] Layout
+    - [x] Color Theme
 - Misc
     - [x] LLM Integration
         - [x] Claude Code status markers via hooks

--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ preset = "default"        # see the table below
 quit           = ["q", "Esc"]
 new_session    = "C-n"
 
-[hooks.claude]            # per-state markers: glyph + colour ("spinner" animates)
-working = { glyph = "spinner", color = "208" }
-waiting = { glyph = "◆", color = "208" }
+[hooks.claude]            # per-state markers: glyph + hex colour ("spinner" animates)
+working = { glyph = "spinner", color = "#ff8700" }
+waiting = { glyph = "◆", color = "#ff8700" }
 
 [layout]
 session_panel_width = 30  # left panel width (%); tree_split / multi_selected_ratio too
@@ -106,33 +106,37 @@ exit_on_switch = true     # exit after switching to a session
 
 Set `theme.preset` to one of:
 
-| Preset | Notes |
-| ------ | ----- |
-| `default` | The original palette (orange markers, cyan/yellow accents). |
+| Preset       | Notes                                                         |
+| ------       | -----                                                         |
+| `default`    | The original palette (orange markers, cyan/yellow accents).   |
 | `monochrome` | Distinguished by brightness, not hue — colour-blind friendly. |
-| `dracula` | |
-| `nord` | |
-| `gruvbox` | |
-| `tokyonight` | |
-| `catppuccin` | Mocha flavour. |
-| `solarized` | Dark variant. |
-| `cyberdream` | |
-| `carbonfox` | |
+| `dracula`    |                                                               |
+| `nord`       |                                                               |
+| `gruvbox`    |                                                               |
+| `tokyonight` |                                                               |
+| `catppuccin` | Mocha flavour.                                                |
+| `solarized`  | Dark variant.                                                 |
+| `cyberdream` |                                                               |
+| `carbonfox`  |                                                               |
 
-Colour values are a name (`red`, `darkgray`, `lightblue`…), a 256-colour index
-(`"208"`), or truecolor hex (`"#rrggbb"`).
+Theme colour values are a name (`red`, `darkgray`, `lightblue`…), a 256-colour
+index (`"208"`), or truecolor hex (`"#rrggbb"`). **Marker colours under
+`[hooks.*]` are hex codes only** (e.g. `color = "#ff8700"`).
 
 ## Key bindings
 
+The status bar at the bottom of the deck always reflects your current bindings,
+so remapping (e.g. `kill_session = "C-d"`) updates the on-screen hint too.
+
 The remappable actions and their defaults:
 
-| Action | Default | Action | Default |
-| ------ | ------- | ------ | ------- |
-| `quit` | `q`, `Esc` | `new_session` | `C-n` |
-| `refresh` | `r` | `rename_session` | `C-r` |
-| `sort` | `s` | `kill_session` | `C-x` |
-| `group` | `g` | `enter` | `Enter` |
-| `input` | `i` | | |
+| Action    | Default    | Action           | Default |
+| ------    | -------    | ------           | ------- |
+| `quit`    | `q`, `Esc` | `new_session`    | `C-n`   |
+| `refresh` | `r`        | `rename_session` | `C-r`   |
+| `sort`    | `s`        | `kill_session`   | `C-x`   |
+| `group`   | `g`        | `enter`          | `Enter` |
+| `input`   | `i`        |                  |         |
 
 A binding is one key string or a list. Modifiers are joined with `-` (`C`/`Ctrl`,
 `S`/`Shift`, `A`/`M`/`Alt`); keys are a single character or a name (`Esc`, `Tab`,
@@ -147,13 +151,13 @@ the Claude **hooks**, the marker reflects what Claude is *doing* in each pane.
 States are distinguished by the marker **shape** (the colour is always the
 same), so they stay legible on any terminal palette:
 
-| Marker | State | Meaning |
-| ------ | ----- | ------- |
-| `⠋⠙⠹…` (animated) | Working | A prompt was submitted / a tool is running |
-| `◆` | Waiting | Claude is waiting on you (permission / idle prompt) |
-| `✓` | Done | Claude finished its turn |
-| `✗` | Error | The turn ended with an error |
-| `●` | Running | Claude process detected, no hook state yet |
+| Marker            | State   | Meaning                                             |
+| ------            | -----   | -------                                             |
+| `⠋⠙⠹…` (animated) | Working | A prompt was submitted / a tool is running          |
+| `◆`               | Waiting | Claude is waiting on you (permission / idle prompt) |
+| `✓`               | Done    | Claude finished its turn                            |
+| `✗`               | Error   | The turn ended with an error                        |
+| `●`               | Running | Claude process detected, no hook state yet          |
 
 Windows and sessions roll up to the most attention-worthy state of their
 children (waiting > error > working > done).
@@ -226,7 +230,7 @@ Written in Rust for maximum performance and minimal resource usage.
     - [ ] Saving and Restoring sessions
     - [ ] Sort
         - [x] Most Recently Used
-        - [ ] Alphabet
+        - [x] Alphabet
         - [ ] Pinning
 - [x] Multi Preview
     - [x] Injection command to pane
@@ -239,7 +243,7 @@ Written in Rust for maximum performance and minimal resource usage.
 - Misc
     - [x] LLM Integration
         - [x] Claude Code status markers via hooks
-    - [ ] Installation for nix
+    - [x] Installation for nix
 
 # License
 MIT License.

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -13,7 +13,7 @@
 [preview]
 # Preview refresh interval in milliseconds. The CLI flag `--interval` overrides
 # this; this overrides the built-in default of 300.
-interval = 300
+interval = 50
 
 # -----------------------------------------------------------------------------
 [theme]
@@ -22,6 +22,7 @@ interval = 300
 #   tokyonight    catppuccin   solarized   cyberdream  carbonfox
 # `monochrome` distinguishes states by brightness rather than hue (good for
 # colour-blind users and minimal terminals).
+# preset = "default"
 preset = "default"
 
 # Optionally override individual semantic roles on top of the preset. Each value
@@ -37,7 +38,7 @@ preset = "default"
 # error          = "red"        # errors and destructive actions (kill)
 # success        = "green"      # creation accents (new / rename / "No")
 # highlight      = "magenta"    # attention accent (multi-preview hint)
-# claude_marker  = "208"        # default colour of the Claude markers
+# (Claude marker colours are configured per-state under [hooks.claude] below.)
 
 # -----------------------------------------------------------------------------
 [keybindings]
@@ -63,21 +64,22 @@ kill_session   = "C-x"
 
 # -----------------------------------------------------------------------------
 # Markers shown for hook-driven agent states. Each marker has a `glyph` and a
-# `color`. The special glyph "spinner" renders the animated braille spinner.
+# `color`. The colour is a hex colour code ("#rrggbb"). The special glyph
+# "spinner" renders the animated braille spinner.
 [hooks.claude]
-working = { glyph = "spinner", color = "208" }  # prompt submitted / tool running
-waiting = { glyph = "◆", color = "208" }        # waiting on you (permission/idle)
-done    = { glyph = "✓", color = "208" }         # finished its turn
-error   = { glyph = "✗", color = "208" }         # turn ended with an error
-running = { glyph = "●", color = "208" }         # process detected, no hook state
+working = { glyph = "spinner", color = "#ff8700" } # prompt submitted / tool running
+waiting = { glyph = "◆", color = "#ff8700" }       # waiting on you (permission/idle)
+done    = { glyph = "✓", color = "#ff8700" }        # finished its turn
+error   = { glyph = "✗", color = "#ff8700" }        # turn ended with an error
+running = { glyph = "●", color = "#ff8700" }        # process detected, no hook state
 
 # Reserved for future Codex hook integration; currently parsed but not consumed.
 [hooks.codex]
-# working = { glyph = "spinner", color = "39" }
-# waiting = { glyph = "◆", color = "39" }
-# done    = { glyph = "✓", color = "39" }
-# error   = { glyph = "✗", color = "39" }
-# running = { glyph = "●", color = "39" }
+# working = { glyph = "spinner", color = "#5fafff" }
+# waiting = { glyph = "◆", color = "#5fafff" }
+# done    = { glyph = "✓", color = "#5fafff" }
+# error   = { glyph = "✗", color = "#5fafff" }
+# running = { glyph = "●", color = "#5fafff" }
 
 # -----------------------------------------------------------------------------
 [layout]

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -1,0 +1,97 @@
+# tmux-deck configuration (example)
+#
+# Copy this file to:
+#   $XDG_CONFIG_HOME/tmux-deck/config.toml   (usually ~/.config/tmux-deck/config.toml)
+# and uncomment/edit the settings you want to change.
+#
+# tmux-deck is zero-config: every setting below is optional and falls back to
+# the built-in default shown here. A missing or malformed file simply uses the
+# defaults (a warning is logged for a malformed one) so a broken config can
+# never stop the app from starting.
+
+# -----------------------------------------------------------------------------
+[preview]
+# Preview refresh interval in milliseconds. The CLI flag `--interval` overrides
+# this; this overrides the built-in default of 300.
+interval = 300
+
+# -----------------------------------------------------------------------------
+[theme]
+# A named colour preset. One of:
+#   default       monochrome   dracula     nord        gruvbox
+#   tokyonight    catppuccin   solarized   cyberdream  carbonfox
+# `monochrome` distinguishes states by brightness rather than hue (good for
+# colour-blind users and minimal terminals).
+preset = "default"
+
+# Optionally override individual semantic roles on top of the preset. Each value
+# is a colour name (`red`, `darkgray`, `lightblue`, …), a 256-colour index
+# ("208"), or a truecolor hex ("#rrggbb").
+[theme.colors]
+# focus_border   = "yellow"     # border of the focused list
+# unfocus_border = "darkgray"   # border of unfocused lists / muted text
+# accent         = "cyan"       # preview/popup borders, headers, info
+# selection_bg   = "darkgray"   # selected row background
+# selection_fg   = "white"      # selected row foreground
+# status_bar_bg  = "darkgray"   # status bar background
+# error          = "red"        # errors and destructive actions (kill)
+# success        = "green"      # creation accents (new / rename / "No")
+# highlight      = "magenta"    # attention accent (multi-preview hint)
+# claude_marker  = "208"        # default colour of the Claude markers
+
+# -----------------------------------------------------------------------------
+[keybindings]
+# Remap the main actions. A binding is a single key string or a list of them.
+# Syntax: a base key, optionally prefixed with modifiers joined by `-`:
+#   modifiers : C/Ctrl (control), S/Shift, A/M/Alt
+#   keys      : a single character, or one of
+#               Esc Enter Tab BackTab Up Down Left Right Space Home End
+#               Backspace Delete
+# Examples: "q", "C-n", "S-Tab", "Space".
+#
+# Note: navigation (j/k/h/l, arrows, Tab) and the `za` fold / double-Space
+# chords are fixed and not (yet) remappable.
+quit           = ["q", "Esc"]
+refresh        = "r"
+sort           = "s"            # TreeView + Sessions focus only
+group          = "g"            # TreeView + Sessions focus only
+input          = "i"
+enter          = "Enter"
+new_session    = "C-n"
+rename_session = "C-r"
+kill_session   = "C-x"
+
+# -----------------------------------------------------------------------------
+# Markers shown for hook-driven agent states. Each marker has a `glyph` and a
+# `color`. The special glyph "spinner" renders the animated braille spinner.
+[hooks.claude]
+working = { glyph = "spinner", color = "208" }  # prompt submitted / tool running
+waiting = { glyph = "◆", color = "208" }        # waiting on you (permission/idle)
+done    = { glyph = "✓", color = "208" }         # finished its turn
+error   = { glyph = "✗", color = "208" }         # turn ended with an error
+running = { glyph = "●", color = "208" }         # process detected, no hook state
+
+# Reserved for future Codex hook integration; currently parsed but not consumed.
+[hooks.codex]
+# working = { glyph = "spinner", color = "39" }
+# waiting = { glyph = "◆", color = "39" }
+# done    = { glyph = "✓", color = "39" }
+# error   = { glyph = "✗", color = "39" }
+# running = { glyph = "●", color = "39" }
+
+# -----------------------------------------------------------------------------
+[layout]
+# Width of the left (lists) panel as a percentage; the preview gets the rest.
+session_panel_width = 30
+# Vertical split of the left panel: Sessions / Windows / Panes (percentages).
+tree_split = [30, 35, 35]
+# In MultiPreview, the width percentage of the selected session; the others
+# share what remains.
+multi_selected_ratio = 70
+
+# -----------------------------------------------------------------------------
+[behavior]
+default_view    = "tree"   # startup view: "tree" or "multi"
+default_sort    = "recent" # "recent", "recent_asc", "abc", "abc_asc"
+double_space_ms = 300      # window for a double-Space to toggle the view
+exit_on_switch  = true     # exit tmux-deck after switching to a session (Enter)

--- a/src/actor/ui_actor.rs
+++ b/src/actor/ui_actor.rs
@@ -9,6 +9,7 @@ use tokio::sync::{mpsc, oneshot};
 
 use crate::actor::messages::{RefreshControl, TmuxCommand, TmuxResponse, UIEvent};
 use crate::app::{Focus, GroupChoice, InputMode, PopupMode, UIState, ViewMode};
+use crate::config::Action;
 use crate::ui::render_ui;
 
 // =============================================================================
@@ -299,6 +300,8 @@ impl UIActor {
 
     async fn handle_normal_mode_key(&mut self, key: event::KeyEvent) -> Result<bool> {
         let is_ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+        let in_sessions = self.state.view_mode == ViewMode::TreeView
+            && self.state.focus == Focus::Sessions;
 
         // `za` fold chord: a pending `z` followed by `a` toggles the current
         // group's fold. Any other key cancels the chord and is then processed
@@ -311,56 +314,51 @@ impl UIActor {
             }
         }
 
-        if is_ctrl {
+        // Fixed (non-remappable) chords handled before config bindings:
+        // `z` begins the `za` fold chord, double-`Space` toggles the view.
+        if !is_ctrl {
             match key.code {
-                KeyCode::Char('n') => {
-                    self.state.open_new_session_popup();
-                    self.refresh_control.pause();
-                }
-                KeyCode::Char('r') => {
-                    self.state.open_rename_session_popup();
-                    self.refresh_control.pause();
-                }
-                KeyCode::Char('x') => {
-                    self.state.open_kill_session_popup();
-                    self.refresh_control.pause();
-                }
-                _ => {}
-            }
-        } else {
-            match key.code {
-                KeyCode::Char('q') | KeyCode::Esc => return Ok(true), // Exit
-                KeyCode::Char('r') => {
-                    let _ = self.tmux_cmd_tx.send(TmuxCommand::RefreshAll).await;
-                }
-                KeyCode::Char('s')
-                    if self.state.view_mode == ViewMode::TreeView
-                        && self.state.focus == Focus::Sessions =>
-                {
-                    self.state.cycle_session_sort();
-                }
-                KeyCode::Char('g')
-                    if self.state.view_mode == ViewMode::TreeView
-                        && self.state.focus == Focus::Sessions =>
-                {
-                    self.state.open_group_session_popup();
-                    self.refresh_control.pause();
-                }
-                KeyCode::Char('z')
-                    if self.state.view_mode == ViewMode::TreeView
-                        && self.state.focus == Focus::Sessions =>
-                {
-                    // Begin the `za` fold chord; the next key resolves it.
+                KeyCode::Char('z') if in_sessions => {
                     self.state.pending_z = true;
+                    return Ok(false);
                 }
                 KeyCode::Char(' ') => {
                     self.state.handle_space_press();
+                    return Ok(false);
                 }
-                KeyCode::Char('i') => {
+                _ => {}
+            }
+        }
+
+        // Remappable actions, resolved through the user's key bindings.
+        if let Some(action) = self.state.keybindings.action_for(&key) {
+            match action {
+                Action::Quit => return Ok(true),
+                Action::Refresh => {
+                    let _ = self.tmux_cmd_tx.send(TmuxCommand::RefreshAll).await;
+                }
+                Action::Sort if in_sessions => self.state.cycle_session_sort(),
+                Action::Group if in_sessions => {
+                    self.state.open_group_session_popup();
+                    self.refresh_control.pause();
+                }
+                Action::Input => {
                     self.state.enter_input_mode();
                     self.refresh_control.pause();
                 }
-                KeyCode::Enter => {
+                Action::NewSession => {
+                    self.state.open_new_session_popup();
+                    self.refresh_control.pause();
+                }
+                Action::RenameSession => {
+                    self.state.open_rename_session_popup();
+                    self.refresh_control.pause();
+                }
+                Action::KillSession => {
+                    self.state.open_kill_session_popup();
+                    self.refresh_control.pause();
+                }
+                Action::Enter => {
                     if let Some(target) = self.state.get_enter_target() {
                         let (reply_tx, reply_rx) = oneshot::channel();
                         let _ = self
@@ -371,14 +369,26 @@ impl UIActor {
                             })
                             .await;
                         let _ = reply_rx.await;
-                        return Ok(true); // Exit after switch
+                        // Optionally keep the deck open after switching.
+                        if self.state.behavior.exit_on_switch {
+                            return Ok(true);
+                        }
                     }
                 }
-                _ => {
-                    // View-specific key handling
-                    self.handle_navigation_key(key.code);
+                // Context-gated actions whose gate is not satisfied fall through
+                // to navigation so the key is not swallowed.
+                Action::Sort | Action::Group => {
+                    if !is_ctrl {
+                        self.handle_navigation_key(key.code);
+                    }
                 }
             }
+            return Ok(false);
+        }
+
+        // Unbound keys: view-specific navigation (only without Ctrl).
+        if !is_ctrl {
+            self.handle_navigation_key(key.code);
         }
         Ok(false)
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -5,6 +5,7 @@ use ansi_to_tui::IntoText;
 use ratatui::text::Text;
 use ratatui::widgets::ListState;
 
+use crate::config::{BehaviorConfig, Config, HooksConfig, KeyBindings, LayoutConfig, Theme};
 use crate::group::GroupStore;
 
 /// Label shown for the implicit group of sessions that have not been assigned
@@ -389,6 +390,19 @@ pub struct UIState {
     pub last_error: Option<String>,
     #[allow(dead_code)]
     pub interval: Duration,
+
+    // Resolved user configuration.
+    /// Semantic UI colour palette.
+    pub theme: Theme,
+    /// Per-state hook markers (claude / codex).
+    pub hooks: HooksConfig,
+    /// Remappable key bindings.
+    pub keybindings: KeyBindings,
+    /// Panel layout ratios.
+    pub layout: LayoutConfig,
+    /// Behavioural toggles (double-space window, exit-on-switch, …).
+    pub behavior: BehaviorConfig,
+
     pub input_mode: InputMode,
     pub input_buffer: String,
     pub input_cursor: usize,
@@ -405,9 +419,13 @@ pub struct UIState {
 }
 
 impl UIState {
-    pub fn new(interval_ms: u64) -> Self {
+    pub fn new(config: Config) -> Self {
+        let interval_ms = config.preview.interval.unwrap_or(300);
+        let theme = config.theme.resolve();
+        let view_mode = config.behavior.view_mode();
+        let session_sort = config.behavior.session_sort();
         let mut state = Self {
-            view_mode: ViewMode::TreeView,
+            view_mode,
             last_space_press: None,
 
             sessions: Vec::new(),
@@ -418,7 +436,7 @@ impl UIState {
             session_list_state: ListState::default(),
             window_list_state: ListState::default(),
             pane_list_state: ListState::default(),
-            session_sort: SessionSort::default(),
+            session_sort,
 
             groups: GroupStore::load(),
             collapsed_groups: HashSet::new(),
@@ -431,6 +449,13 @@ impl UIState {
             pane_content_parsed: None,
             last_error: None,
             interval: Duration::from_millis(interval_ms),
+
+            theme,
+            hooks: config.hooks,
+            keybindings: config.keybindings,
+            layout: config.layout,
+            behavior: config.behavior,
+
             input_mode: InputMode::Normal,
             input_buffer: String::new(),
             input_cursor: 0,
@@ -469,7 +494,7 @@ impl UIState {
     pub fn handle_space_press(&mut self) -> bool {
         let now = Instant::now();
         if let Some(last) = self.last_space_press
-            && now.duration_since(last) < Duration::from_millis(300)
+            && now.duration_since(last) < Duration::from_millis(self.behavior.double_space_ms)
         {
             // Double space detected
             self.toggle_view_mode();
@@ -1113,7 +1138,7 @@ mod tests {
     /// Build a UIState with an in-memory (no-disk) group store and the given
     /// assignments, then load `names` as the session list.
     fn state_with(names: &[&str], groups: &[(&str, &str)]) -> UIState {
-        let mut state = UIState::new(100);
+        let mut state = UIState::new(Config::default());
         state.groups = GroupStore::default();
         for (sess, grp) in groups {
             state.groups.set(sess, Some(grp));

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,15 +8,15 @@ use std::path::PathBuf;
 #[derive(Debug, Parser)]
 #[command(author, name="tmux-deck", about="a tmux session manager and monitoring multi sessions.", version, long_about=None)]
 pub struct Cli {
-    /// Config file
-    #[arg(short, long, default_value = "~/.config/tmux_deck/config.toml")]
+    /// Config file (defaults to $XDG_CONFIG_HOME/tmux-deck/config.toml)
+    #[arg(short, long)]
     pub config: Option<PathBuf>,
     /// Target pane (e.g., "session:window.pane" or "%123")
     #[arg(short, long)]
     pub target: Option<String>,
-    /// Preview refresh interval in milliseconds
-    #[arg(short, long, default_value = "300")]
-    pub interval: u64,
+    /// Preview refresh interval in milliseconds (overrides the config file)
+    #[arg(short, long)]
+    pub interval: Option<u64>,
     /// Subcommand (omit to launch the interactive TUI)
     #[command(subcommand)]
     pub command: Option<Command>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,883 @@
+//! User configuration loaded from a TOML file.
+//!
+//! tmux-deck is zero-config by default: when no config file exists the built-in
+//! defaults reproduce the previous hard-coded behaviour exactly. A config file
+//! lets the user tune the preview interval, the colour theme, key bindings, the
+//! per-state Claude hook markers (and, in future, Codex markers), the panel
+//! layout and a handful of behavioural toggles.
+//!
+//! Loading is best-effort, mirroring [`crate::group::GroupStore`]: a missing
+//! file yields defaults, and an unreadable / malformed file logs a warning and
+//! falls back to defaults so a broken config can never stop the app starting.
+//!
+//! Resolution order for the file path:
+//!   1. `--config <path>` on the CLI (`~` is expanded)
+//!   2. `$XDG_CONFIG_HOME/tmux-deck/config.toml` (via the `directories` crate)
+//!   3. built-in defaults (no file)
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use directories::ProjectDirs;
+use ratatui::style::Color;
+use serde::Deserialize;
+use serde::de::{self, Deserializer};
+use tracing::{debug, warn};
+
+use crate::app::{SessionSort, SessionSortKey, SortDirection, ViewMode};
+
+// =============================================================================
+// Top-level config
+// =============================================================================
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct Config {
+    pub preview: PreviewConfig,
+    pub theme: ThemeConfig,
+    pub keybindings: KeyBindings,
+    pub hooks: HooksConfig,
+    pub layout: LayoutConfig,
+    pub behavior: BehaviorConfig,
+}
+
+impl Config {
+    /// Load the config, preferring an explicit `--config` path, then the XDG
+    /// config dir, then built-in defaults. Never fails: any error degrades to
+    /// the default config with a warning.
+    pub fn load(cli_path: Option<&Path>) -> Self {
+        let path = cli_path
+            .map(expand_tilde)
+            .or_else(Self::default_path);
+        let Some(path) = path else {
+            return Self::default();
+        };
+        match std::fs::read_to_string(&path) {
+            Ok(contents) => match toml::from_str::<Config>(&contents) {
+                Ok(cfg) => {
+                    debug!("loaded config from {}", path.display());
+                    cfg
+                }
+                Err(e) => {
+                    warn!("failed to parse config {}: {e}; using defaults", path.display());
+                    Self::default()
+                }
+            },
+            // Missing file is the common zero-config case: silently use defaults.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Self::default(),
+            Err(e) => {
+                warn!("failed to read config {}: {e}; using defaults", path.display());
+                Self::default()
+            }
+        }
+    }
+
+    fn default_path() -> Option<PathBuf> {
+        let dirs = ProjectDirs::from("dev", "tkcd", "tmux-deck")?;
+        Some(dirs.config_dir().join("config.toml"))
+    }
+}
+
+/// Expand a leading `~` to the user's home directory.
+fn expand_tilde(p: &Path) -> PathBuf {
+    if let Ok(stripped) = p.strip_prefix("~")
+        && let Some(home) = std::env::var_os("HOME")
+    {
+        return PathBuf::from(home).join(stripped);
+    }
+    p.to_path_buf()
+}
+
+// =============================================================================
+// [preview]
+// =============================================================================
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct PreviewConfig {
+    /// Preview refresh interval in milliseconds. `None` lets the CLI flag / the
+    /// built-in default (300ms) win, so the precedence is CLI > config > 300.
+    pub interval: Option<u64>,
+}
+
+// =============================================================================
+// [behavior]
+// =============================================================================
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct BehaviorConfig {
+    /// View shown on startup: `tree` or `multi`.
+    pub default_view: String,
+    /// Initial session sort: `recent`, `recent_asc`, `abc`, `abc_asc`.
+    pub default_sort: String,
+    /// Window (ms) within which a second Space press toggles the view mode.
+    pub double_space_ms: u64,
+    /// Whether selecting a session/window (Enter) exits tmux-deck after the
+    /// tmux client switch. When false, the deck stays open.
+    pub exit_on_switch: bool,
+}
+
+impl Default for BehaviorConfig {
+    fn default() -> Self {
+        Self {
+            default_view: "tree".to_string(),
+            default_sort: "recent".to_string(),
+            double_space_ms: 300,
+            exit_on_switch: true,
+        }
+    }
+}
+
+impl BehaviorConfig {
+    pub fn view_mode(&self) -> ViewMode {
+        match self.default_view.to_ascii_lowercase().as_str() {
+            "multi" | "multipreview" => ViewMode::MultiPreview,
+            _ => ViewMode::TreeView,
+        }
+    }
+
+    pub fn session_sort(&self) -> SessionSort {
+        match self.default_sort.to_ascii_lowercase().as_str() {
+            "recent_asc" | "oldest" => SessionSort {
+                key: SessionSortKey::LastAttached,
+                direction: SortDirection::Asc,
+            },
+            "abc" | "alphabet" => SessionSort {
+                key: SessionSortKey::Alphabet,
+                direction: SortDirection::Desc,
+            },
+            "abc_asc" | "alphabet_asc" => SessionSort {
+                key: SessionSortKey::Alphabet,
+                direction: SortDirection::Asc,
+            },
+            // "recent" / unknown -> the historical default (most recent first).
+            _ => SessionSort {
+                key: SessionSortKey::LastAttached,
+                direction: SortDirection::Desc,
+            },
+        }
+    }
+}
+
+// =============================================================================
+// [layout]
+// =============================================================================
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct LayoutConfig {
+    /// Width of the left (lists) panel as a percentage of the screen; the
+    /// preview takes the rest. TreeView only.
+    pub session_panel_width: u16,
+    /// Vertical split of the left panel into Sessions / Windows / Panes, as
+    /// three percentages.
+    pub tree_split: [u16; 3],
+    /// In MultiPreview, the width percentage given to the selected session; the
+    /// remaining sessions share what's left.
+    pub multi_selected_ratio: u16,
+}
+
+impl Default for LayoutConfig {
+    fn default() -> Self {
+        Self {
+            session_panel_width: 30,
+            tree_split: [30, 35, 35],
+            multi_selected_ratio: 70,
+        }
+    }
+}
+
+// =============================================================================
+// [theme]
+// =============================================================================
+
+/// Raw theme config as written in TOML: a preset name plus optional per-role
+/// colour overrides. Resolved into a concrete [`Theme`] via [`Self::resolve`].
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct ThemeConfig {
+    pub preset: String,
+    pub colors: HashMap<String, String>,
+}
+
+impl Default for ThemeConfig {
+    fn default() -> Self {
+        Self {
+            preset: "default".to_string(),
+            colors: HashMap::new(),
+        }
+    }
+}
+
+impl ThemeConfig {
+    /// Resolve the preset and apply any per-role overrides. Unknown colour
+    /// strings / role names are ignored with a warning so a typo never breaks
+    /// rendering.
+    pub fn resolve(&self) -> Theme {
+        let mut theme = Theme::preset(&self.preset);
+        for (role, value) in &self.colors {
+            match parse_color(value) {
+                Some(color) if theme.set(role, color) => {}
+                Some(_) => warn!("unknown theme colour role '{role}', ignoring"),
+                None => warn!("invalid colour '{value}' for role '{role}', ignoring"),
+            }
+        }
+        theme
+    }
+}
+
+/// A resolved set of semantic UI colours. Roles are intentionally coarse so the
+/// presets stay easy to define; the renderer maps each widget onto one role.
+#[derive(Debug, Clone, Copy)]
+pub struct Theme {
+    /// Border of the focused list.
+    pub focus_border: Color,
+    /// Border of unfocused lists.
+    pub unfocus_border: Color,
+    /// General accent: preview/popup borders, headers, info text.
+    pub accent: Color,
+    /// Background of the selected row.
+    pub selection_bg: Color,
+    /// Foreground of the selected row.
+    pub selection_fg: Color,
+    /// Background of the status bar.
+    pub status_bar_bg: Color,
+    /// Errors and destructive actions (e.g. kill).
+    pub error: Color,
+    /// Success / creation accents (e.g. new / rename hints, "No" button).
+    pub success: Color,
+    /// Attention accent used sparingly (e.g. the multi-preview hint).
+    pub highlight: Color,
+    /// Single colour used for every Claude marker by default.
+    pub claude_marker: Color,
+}
+
+impl Default for Theme {
+    fn default() -> Self {
+        Self::preset("default")
+    }
+}
+
+impl Theme {
+    /// Apply an override to the named role. Returns false for unknown roles.
+    fn set(&mut self, role: &str, color: Color) -> bool {
+        match role {
+            "focus_border" => self.focus_border = color,
+            "unfocus_border" => self.unfocus_border = color,
+            "accent" => self.accent = color,
+            "selection_bg" => self.selection_bg = color,
+            "selection_fg" => self.selection_fg = color,
+            "status_bar_bg" => self.status_bar_bg = color,
+            "error" => self.error = color,
+            "success" => self.success = color,
+            "highlight" => self.highlight = color,
+            "claude_marker" => self.claude_marker = color,
+            _ => return false,
+        }
+        true
+    }
+
+    /// Look up a named preset, falling back to `default` for unknown names.
+    pub fn preset(name: &str) -> Self {
+        let rgb = Color::Rgb;
+        match name.to_ascii_lowercase().as_str() {
+            // The historical hard-coded palette, kept byte-for-byte so an
+            // unconfigured deck looks exactly as before.
+            "default" => Self {
+                focus_border: Color::Yellow,
+                unfocus_border: Color::DarkGray,
+                accent: Color::Cyan,
+                selection_bg: Color::DarkGray,
+                selection_fg: Color::White,
+                status_bar_bg: Color::DarkGray,
+                error: Color::Red,
+                success: Color::Green,
+                highlight: Color::Magenta,
+                claude_marker: Color::Indexed(208),
+            },
+            // Distinguished by brightness, not hue (colour-blind friendly).
+            "monochrome" => Self {
+                focus_border: rgb(0xff, 0xff, 0xff),
+                unfocus_border: rgb(0x5c, 0x63, 0x70),
+                accent: rgb(0xab, 0xb2, 0xbf),
+                selection_bg: rgb(0x3e, 0x44, 0x51),
+                selection_fg: rgb(0xff, 0xff, 0xff),
+                status_bar_bg: rgb(0x3e, 0x44, 0x51),
+                error: rgb(0xff, 0xff, 0xff),
+                success: rgb(0xab, 0xb2, 0xbf),
+                highlight: rgb(0xff, 0xff, 0xff),
+                claude_marker: rgb(0xff, 0xff, 0xff),
+            },
+            "dracula" => Self {
+                focus_border: rgb(0xf1, 0xfa, 0x8c),  // yellow
+                unfocus_border: rgb(0x62, 0x72, 0xa4), // comment
+                accent: rgb(0x8b, 0xe9, 0xfd),         // cyan
+                selection_bg: rgb(0x44, 0x47, 0x5a),   // current line
+                selection_fg: rgb(0xf8, 0xf8, 0xf2),   // foreground
+                status_bar_bg: rgb(0x44, 0x47, 0x5a),
+                error: rgb(0xff, 0x55, 0x55),          // red
+                success: rgb(0x50, 0xfa, 0x7b),        // green
+                highlight: rgb(0xbd, 0x93, 0xf9),      // purple
+                claude_marker: rgb(0xff, 0xb8, 0x6c),  // orange
+            },
+            "nord" => Self {
+                focus_border: rgb(0xeb, 0xcb, 0x8b),
+                unfocus_border: rgb(0x4c, 0x56, 0x6a),
+                accent: rgb(0x88, 0xc0, 0xd0),
+                selection_bg: rgb(0x43, 0x4c, 0x5e),
+                selection_fg: rgb(0xec, 0xef, 0xf4),
+                status_bar_bg: rgb(0x3b, 0x42, 0x52),
+                error: rgb(0xbf, 0x61, 0x6a),
+                success: rgb(0xa3, 0xbe, 0x8c),
+                highlight: rgb(0xb4, 0x8e, 0xad),
+                claude_marker: rgb(0xd0, 0x87, 0x70),
+            },
+            "gruvbox" => Self {
+                focus_border: rgb(0xfa, 0xbd, 0x2f),
+                unfocus_border: rgb(0x92, 0x83, 0x74),
+                accent: rgb(0x8e, 0xc0, 0x7c),
+                selection_bg: rgb(0x3c, 0x38, 0x36),
+                selection_fg: rgb(0xeb, 0xdb, 0xb2),
+                status_bar_bg: rgb(0x3c, 0x38, 0x36),
+                error: rgb(0xfb, 0x49, 0x34),
+                success: rgb(0xb8, 0xbb, 0x26),
+                highlight: rgb(0xd3, 0x86, 0x9b),
+                claude_marker: rgb(0xfe, 0x80, 0x19),
+            },
+            "tokyonight" => Self {
+                focus_border: rgb(0xe0, 0xaf, 0x68),
+                unfocus_border: rgb(0x56, 0x5f, 0x89),
+                accent: rgb(0x7d, 0xcf, 0xff),
+                selection_bg: rgb(0x28, 0x2e, 0x44),
+                selection_fg: rgb(0xc0, 0xca, 0xf5),
+                status_bar_bg: rgb(0x24, 0x28, 0x3b),
+                error: rgb(0xf7, 0x76, 0x8e),
+                success: rgb(0x9e, 0xce, 0x6a),
+                highlight: rgb(0xbb, 0x9a, 0xf7),
+                claude_marker: rgb(0xff, 0x9e, 0x64),
+            },
+            "catppuccin" => Self {
+                focus_border: rgb(0xf9, 0xe2, 0xaf),
+                unfocus_border: rgb(0x6c, 0x70, 0x86),
+                accent: rgb(0x89, 0xdc, 0xeb),
+                selection_bg: rgb(0x31, 0x32, 0x44),
+                selection_fg: rgb(0xcd, 0xd6, 0xf4),
+                status_bar_bg: rgb(0x31, 0x32, 0x44),
+                error: rgb(0xf3, 0x8b, 0xa8),
+                success: rgb(0xa6, 0xe3, 0xa1),
+                highlight: rgb(0xcb, 0xa6, 0xf7),
+                claude_marker: rgb(0xfa, 0xb3, 0x87),
+            },
+            "solarized" => Self {
+                focus_border: rgb(0xb5, 0x89, 0x00),
+                unfocus_border: rgb(0x58, 0x6e, 0x75),
+                accent: rgb(0x2a, 0xa1, 0x98),
+                selection_bg: rgb(0x07, 0x36, 0x42),
+                selection_fg: rgb(0x93, 0xa1, 0xa1),
+                status_bar_bg: rgb(0x07, 0x36, 0x42),
+                error: rgb(0xdc, 0x32, 0x2f),
+                success: rgb(0x85, 0x99, 0x00),
+                highlight: rgb(0x6c, 0x71, 0xc4),
+                claude_marker: rgb(0xcb, 0x4b, 0x16),
+            },
+            "cyberdream" => Self {
+                focus_border: rgb(0xf1, 0xff, 0x5e),
+                unfocus_border: rgb(0x7b, 0x84, 0x96),
+                accent: rgb(0x5e, 0xf1, 0xff),
+                selection_bg: rgb(0x3c, 0x40, 0x48),
+                selection_fg: rgb(0xff, 0xff, 0xff),
+                status_bar_bg: rgb(0x3c, 0x40, 0x48),
+                error: rgb(0xff, 0x6e, 0x5e),
+                success: rgb(0x5e, 0xff, 0x6c),
+                highlight: rgb(0xbd, 0x5e, 0xff),
+                claude_marker: rgb(0xff, 0xbd, 0x5e),
+            },
+            "carbonfox" => Self {
+                focus_border: rgb(0x08, 0xbd, 0xba),
+                unfocus_border: rgb(0x6f, 0x6f, 0x6f),
+                accent: rgb(0x33, 0xb1, 0xff),
+                selection_bg: rgb(0x28, 0x28, 0x28),
+                selection_fg: rgb(0xf2, 0xf4, 0xf8),
+                status_bar_bg: rgb(0x28, 0x28, 0x28),
+                error: rgb(0xee, 0x53, 0x96),
+                success: rgb(0x25, 0xbe, 0x6a),
+                highlight: rgb(0xbe, 0x95, 0xff),
+                claude_marker: rgb(0xff, 0x7e, 0xb6),
+            },
+            other => {
+                warn!("unknown theme preset '{other}', using default");
+                Self::preset("default")
+            }
+        }
+    }
+}
+
+/// Parse a colour string: a name (`red`, `darkgray`, `lightblue`…), a 256-colour
+/// index (`"208"`), or a truecolor hex (`"#rrggbb"`). Returns `None` on anything
+/// unrecognised.
+pub fn parse_color(s: &str) -> Option<Color> {
+    let t = s.trim();
+    if let Some(hex) = t.strip_prefix('#') {
+        if hex.len() == 6 {
+            let r = u8::from_str_radix(&hex[0..2], 16).ok()?;
+            let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
+            let b = u8::from_str_radix(&hex[4..6], 16).ok()?;
+            return Some(Color::Rgb(r, g, b));
+        }
+        return None;
+    }
+    if let Ok(idx) = t.parse::<u8>() {
+        return Some(Color::Indexed(idx));
+    }
+    let color = match t.to_ascii_lowercase().as_str() {
+        "black" => Color::Black,
+        "red" => Color::Red,
+        "green" => Color::Green,
+        "yellow" => Color::Yellow,
+        "blue" => Color::Blue,
+        "magenta" => Color::Magenta,
+        "cyan" => Color::Cyan,
+        "gray" | "grey" => Color::Gray,
+        "darkgray" | "darkgrey" => Color::DarkGray,
+        "white" => Color::White,
+        "lightred" => Color::LightRed,
+        "lightgreen" => Color::LightGreen,
+        "lightyellow" => Color::LightYellow,
+        "lightblue" => Color::LightBlue,
+        "lightmagenta" => Color::LightMagenta,
+        "lightcyan" => Color::LightCyan,
+        "reset" => Color::Reset,
+        _ => return None,
+    };
+    Some(color)
+}
+
+// =============================================================================
+// [hooks.claude] / [hooks.codex]
+// =============================================================================
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct HooksConfig {
+    pub claude: MarkerSet,
+    pub codex: MarkerSet,
+}
+
+/// The five markers shown for a hook-driven agent's states. `running` is shown
+/// when the process is detected but no hook state is known yet.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct MarkerSet {
+    pub working: Marker,
+    pub waiting: Marker,
+    pub done: Marker,
+    pub error: Marker,
+    pub running: Marker,
+}
+
+impl Default for MarkerSet {
+    fn default() -> Self {
+        let color = Color::Indexed(208);
+        Self {
+            working: Marker::spinner(color),
+            waiting: Marker::glyph("◆", color),
+            done: Marker::glyph("✓", color),
+            error: Marker::glyph("✗", color),
+            running: Marker::glyph("●", color),
+        }
+    }
+}
+
+/// A single marker: its glyph and colour. The special glyph `"spinner"` renders
+/// the animated braille spinner instead of a static character.
+#[derive(Debug, Clone)]
+pub struct Marker {
+    pub glyph: String,
+    pub color: Color,
+    /// True when the glyph was the literal `"spinner"` sentinel.
+    pub animated: bool,
+}
+
+impl Marker {
+    fn glyph(g: &str, color: Color) -> Self {
+        Self {
+            glyph: g.to_string(),
+            color,
+            animated: false,
+        }
+    }
+
+    fn spinner(color: Color) -> Self {
+        Self {
+            glyph: "spinner".to_string(),
+            color,
+            animated: true,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Marker {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Raw {
+            glyph: String,
+            #[serde(default)]
+            color: Option<String>,
+        }
+        let raw = Raw::deserialize(deserializer)?;
+        let color = match raw.color.as_deref() {
+            Some(c) => parse_color(c)
+                .ok_or_else(|| de::Error::custom(format!("invalid marker colour: {c}")))?,
+            None => Color::Indexed(208),
+        };
+        Ok(Marker {
+            animated: raw.glyph == "spinner",
+            glyph: raw.glyph,
+            color,
+        })
+    }
+}
+
+// =============================================================================
+// [keybindings]
+// =============================================================================
+
+/// A remappable user action. Navigation (j/k/h/l/arrows/Tab) and chords
+/// (`za` fold, double-Space) are intentionally not remappable yet.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Action {
+    Quit,
+    Refresh,
+    Sort,
+    Group,
+    Input,
+    Enter,
+    NewSession,
+    RenameSession,
+    KillSession,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct KeyBindings {
+    #[serde(deserialize_with = "de_keys")]
+    pub quit: Vec<KeySpec>,
+    #[serde(deserialize_with = "de_keys")]
+    pub refresh: Vec<KeySpec>,
+    #[serde(deserialize_with = "de_keys")]
+    pub sort: Vec<KeySpec>,
+    #[serde(deserialize_with = "de_keys")]
+    pub group: Vec<KeySpec>,
+    #[serde(deserialize_with = "de_keys")]
+    pub input: Vec<KeySpec>,
+    #[serde(deserialize_with = "de_keys")]
+    pub enter: Vec<KeySpec>,
+    #[serde(deserialize_with = "de_keys")]
+    pub new_session: Vec<KeySpec>,
+    #[serde(deserialize_with = "de_keys")]
+    pub rename_session: Vec<KeySpec>,
+    #[serde(deserialize_with = "de_keys")]
+    pub kill_session: Vec<KeySpec>,
+}
+
+impl Default for KeyBindings {
+    fn default() -> Self {
+        // Mirrors the historical hard-coded bindings.
+        Self {
+            quit: vec![key('q'), named(KeyCode::Esc)],
+            refresh: vec![key('r')],
+            sort: vec![key('s')],
+            group: vec![key('g')],
+            input: vec![key('i')],
+            enter: vec![named(KeyCode::Enter)],
+            new_session: vec![ctrl('n')],
+            rename_session: vec![ctrl('r')],
+            kill_session: vec![ctrl('x')],
+        }
+    }
+}
+
+impl KeyBindings {
+    /// Pairs of (action, bindings) in match priority order. Modifier-bearing
+    /// bindings (e.g. `C-r`) are listed so they win over the plain `r` refresh.
+    fn entries(&self) -> [(Action, &Vec<KeySpec>); 9] {
+        [
+            (Action::NewSession, &self.new_session),
+            (Action::RenameSession, &self.rename_session),
+            (Action::KillSession, &self.kill_session),
+            (Action::Quit, &self.quit),
+            (Action::Refresh, &self.refresh),
+            (Action::Sort, &self.sort),
+            (Action::Group, &self.group),
+            (Action::Input, &self.input),
+            (Action::Enter, &self.enter),
+        ]
+    }
+
+    /// The action a key event maps to, if any.
+    pub fn action_for(&self, key: &KeyEvent) -> Option<Action> {
+        self.entries()
+            .into_iter()
+            .find(|(_, specs)| specs.iter().any(|s| s.matches(key)))
+            .map(|(action, _)| action)
+    }
+}
+
+/// A parsed key chord: a base key plus modifiers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct KeySpec {
+    pub code: KeyCode,
+    pub mods: KeyModifiers,
+}
+
+impl KeySpec {
+    /// Whether this spec matches a crossterm key event. Only the C/S/A
+    /// modifiers are considered (other state flags are masked out).
+    pub fn matches(&self, key: &KeyEvent) -> bool {
+        let relevant = KeyModifiers::CONTROL | KeyModifiers::SHIFT | KeyModifiers::ALT;
+        self.code == key.code && (key.modifiers & relevant) == self.mods
+    }
+}
+
+fn key(c: char) -> KeySpec {
+    KeySpec {
+        code: KeyCode::Char(c),
+        mods: KeyModifiers::NONE,
+    }
+}
+
+fn ctrl(c: char) -> KeySpec {
+    KeySpec {
+        code: KeyCode::Char(c),
+        mods: KeyModifiers::CONTROL,
+    }
+}
+
+fn named(code: KeyCode) -> KeySpec {
+    KeySpec {
+        code,
+        mods: KeyModifiers::NONE,
+    }
+}
+
+/// Parse a key string like `q`, `Esc`, `C-n`, `S-Tab`, `Up`, `Space`.
+pub fn parse_key(s: &str) -> Option<KeySpec> {
+    let s = s.trim();
+    if s.is_empty() {
+        return None;
+    }
+    let parts: Vec<&str> = s.split('-').collect();
+    let (mod_parts, key_part) = parts.split_at(parts.len() - 1);
+
+    let mut mods = KeyModifiers::NONE;
+    for m in mod_parts {
+        match m.to_ascii_uppercase().as_str() {
+            "C" | "CTRL" | "CONTROL" => mods |= KeyModifiers::CONTROL,
+            "S" | "SHIFT" => mods |= KeyModifiers::SHIFT,
+            "A" | "M" | "ALT" | "META" => mods |= KeyModifiers::ALT,
+            _ => return None,
+        }
+    }
+
+    let token = key_part[0];
+    let code = match token.to_ascii_lowercase().as_str() {
+        "esc" | "escape" => KeyCode::Esc,
+        "enter" | "return" | "cr" => KeyCode::Enter,
+        "tab" => KeyCode::Tab,
+        "backtab" => KeyCode::BackTab,
+        "up" => KeyCode::Up,
+        "down" => KeyCode::Down,
+        "left" => KeyCode::Left,
+        "right" => KeyCode::Right,
+        "space" => KeyCode::Char(' '),
+        "home" => KeyCode::Home,
+        "end" => KeyCode::End,
+        "backspace" | "bs" => KeyCode::Backspace,
+        "delete" | "del" => KeyCode::Delete,
+        // A single character keeps its original case.
+        _ if token.chars().count() == 1 => KeyCode::Char(token.chars().next().unwrap()),
+        _ => return None,
+    };
+    Some(KeySpec { code, mods })
+}
+
+impl<'de> Deserialize<'de> for KeySpec {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        parse_key(&s).ok_or_else(|| de::Error::custom(format!("invalid key binding: {s}")))
+    }
+}
+
+/// Deserialize a single key string or a list of key strings into `Vec<KeySpec>`.
+fn de_keys<'de, D>(deserializer: D) -> Result<Vec<KeySpec>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum OneOrMany {
+        One(KeySpec),
+        Many(Vec<KeySpec>),
+    }
+    Ok(match OneOrMany::deserialize(deserializer)? {
+        OneOrMany::One(k) => vec![k],
+        OneOrMany::Many(v) => v,
+    })
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_color_forms() {
+        assert_eq!(parse_color("red"), Some(Color::Red));
+        assert_eq!(parse_color("DarkGray"), Some(Color::DarkGray));
+        assert_eq!(parse_color("208"), Some(Color::Indexed(208)));
+        assert_eq!(parse_color("#ff8800"), Some(Color::Rgb(0xff, 0x88, 0x00)));
+        assert_eq!(parse_color("notacolor"), None);
+        assert_eq!(parse_color("#xyz"), None);
+    }
+
+    #[test]
+    fn parses_key_forms() {
+        assert_eq!(parse_key("q"), Some(key('q')));
+        assert_eq!(parse_key("C-n"), Some(ctrl('n')));
+        assert_eq!(parse_key("Esc"), Some(named(KeyCode::Esc)));
+        assert_eq!(parse_key("Space"), Some(named(KeyCode::Char(' '))));
+        assert_eq!(
+            parse_key("C-S-x"),
+            Some(KeySpec {
+                code: KeyCode::Char('x'),
+                mods: KeyModifiers::CONTROL | KeyModifiers::SHIFT
+            })
+        );
+        assert_eq!(
+            parse_key("BackTab"),
+            Some(named(KeyCode::BackTab))
+        );
+        assert_eq!(parse_key(""), None);
+        assert_eq!(parse_key("C-"), None);
+    }
+
+    #[test]
+    fn empty_config_is_default() {
+        let cfg: Config = toml::from_str("").unwrap();
+        assert_eq!(cfg.preview.interval, None);
+        assert_eq!(cfg.behavior.double_space_ms, 300);
+        assert!(cfg.behavior.exit_on_switch);
+        assert_eq!(cfg.layout.session_panel_width, 30);
+        // Default markers match the historical glyphs.
+        assert_eq!(cfg.hooks.claude.done.glyph, "✓");
+        assert!(cfg.hooks.claude.working.animated);
+    }
+
+    #[test]
+    fn partial_config_merges_with_defaults() {
+        let cfg: Config = toml::from_str(
+            r#"
+            [preview]
+            interval = 500
+
+            [keybindings]
+            quit = "x"
+
+            [hooks.claude]
+            done = { glyph = "DONE", color = "green" }
+        "#,
+        )
+        .unwrap();
+        assert_eq!(cfg.preview.interval, Some(500));
+        // Overridden binding takes effect...
+        assert_eq!(cfg.keybindings.quit, vec![key('x')]);
+        // ...while untouched bindings keep their defaults.
+        assert_eq!(cfg.keybindings.refresh, vec![key('r')]);
+        // Overridden marker, and a default sibling marker.
+        assert_eq!(cfg.hooks.claude.done.glyph, "DONE");
+        assert_eq!(cfg.hooks.claude.done.color, Color::Green);
+        assert_eq!(cfg.hooks.claude.waiting.glyph, "◆");
+    }
+
+    #[test]
+    fn keys_accept_single_or_list() {
+        let cfg: Config = toml::from_str(
+            r#"
+            [keybindings]
+            quit = ["q", "Esc", "C-c"]
+        "#,
+        )
+        .unwrap();
+        assert_eq!(cfg.keybindings.quit.len(), 3);
+    }
+
+    #[test]
+    fn theme_preset_and_overrides_resolve() {
+        let cfg: Config = toml::from_str(
+            r##"
+            [theme]
+            preset = "dracula"
+            [theme.colors]
+            accent = "#123456"
+            bogus_role = "red"
+        "##,
+        )
+        .unwrap();
+        let theme = cfg.theme.resolve();
+        // Override applied.
+        assert_eq!(theme.accent, Color::Rgb(0x12, 0x34, 0x56));
+        // Preset value retained for a non-overridden role.
+        assert_eq!(theme.claude_marker, Color::Rgb(0xff, 0xb8, 0x6c));
+    }
+
+    #[test]
+    fn unknown_preset_falls_back_to_default() {
+        let theme = Theme::preset("does-not-exist");
+        assert_eq!(theme.claude_marker, Color::Indexed(208));
+    }
+
+    #[test]
+    fn action_lookup_respects_modifiers() {
+        let kb = KeyBindings::default();
+        let plain_r = KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE);
+        let ctrl_r = KeyEvent::new(KeyCode::Char('r'), KeyModifiers::CONTROL);
+        assert_eq!(kb.action_for(&plain_r), Some(Action::Refresh));
+        assert_eq!(kb.action_for(&ctrl_r), Some(Action::RenameSession));
+        let j = KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE);
+        assert_eq!(kb.action_for(&j), None);
+    }
+
+    #[test]
+    fn shipped_example_config_parses() {
+        // The example we ship must always parse against the current schema.
+        let example = include_str!("../docs/config.example.toml");
+        let cfg: Config = toml::from_str(example).expect("example config must parse");
+        // Spot-check a couple of representative values.
+        assert_eq!(cfg.preview.interval, Some(300));
+        assert_eq!(cfg.theme.preset, "default");
+        assert!(cfg.hooks.claude.working.animated);
+    }
+
+    #[test]
+    fn behavior_maps_view_and_sort() {
+        let b = BehaviorConfig {
+            default_view: "multi".to_string(),
+            default_sort: "abc".to_string(),
+            ..BehaviorConfig::default()
+        };
+        assert_eq!(b.view_mode(), ViewMode::MultiPreview);
+        assert_eq!(b.session_sort().key, SessionSortKey::Alphabet);
+        assert_eq!(b.session_sort().direction, SortDirection::Desc);
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -250,8 +250,6 @@ pub struct Theme {
     pub success: Color,
     /// Attention accent used sparingly (e.g. the multi-preview hint).
     pub highlight: Color,
-    /// Single colour used for every Claude marker by default.
-    pub claude_marker: Color,
 }
 
 impl Default for Theme {
@@ -273,7 +271,6 @@ impl Theme {
             "error" => self.error = color,
             "success" => self.success = color,
             "highlight" => self.highlight = color,
-            "claude_marker" => self.claude_marker = color,
             _ => return false,
         }
         true
@@ -295,7 +292,6 @@ impl Theme {
                 error: Color::Red,
                 success: Color::Green,
                 highlight: Color::Magenta,
-                claude_marker: Color::Indexed(208),
             },
             // Distinguished by brightness, not hue (colour-blind friendly).
             "monochrome" => Self {
@@ -308,7 +304,6 @@ impl Theme {
                 error: rgb(0xff, 0xff, 0xff),
                 success: rgb(0xab, 0xb2, 0xbf),
                 highlight: rgb(0xff, 0xff, 0xff),
-                claude_marker: rgb(0xff, 0xff, 0xff),
             },
             "dracula" => Self {
                 focus_border: rgb(0xf1, 0xfa, 0x8c),  // yellow
@@ -320,7 +315,6 @@ impl Theme {
                 error: rgb(0xff, 0x55, 0x55),          // red
                 success: rgb(0x50, 0xfa, 0x7b),        // green
                 highlight: rgb(0xbd, 0x93, 0xf9),      // purple
-                claude_marker: rgb(0xff, 0xb8, 0x6c),  // orange
             },
             "nord" => Self {
                 focus_border: rgb(0xeb, 0xcb, 0x8b),
@@ -332,7 +326,6 @@ impl Theme {
                 error: rgb(0xbf, 0x61, 0x6a),
                 success: rgb(0xa3, 0xbe, 0x8c),
                 highlight: rgb(0xb4, 0x8e, 0xad),
-                claude_marker: rgb(0xd0, 0x87, 0x70),
             },
             "gruvbox" => Self {
                 focus_border: rgb(0xfa, 0xbd, 0x2f),
@@ -344,7 +337,6 @@ impl Theme {
                 error: rgb(0xfb, 0x49, 0x34),
                 success: rgb(0xb8, 0xbb, 0x26),
                 highlight: rgb(0xd3, 0x86, 0x9b),
-                claude_marker: rgb(0xfe, 0x80, 0x19),
             },
             "tokyonight" => Self {
                 focus_border: rgb(0xe0, 0xaf, 0x68),
@@ -356,7 +348,6 @@ impl Theme {
                 error: rgb(0xf7, 0x76, 0x8e),
                 success: rgb(0x9e, 0xce, 0x6a),
                 highlight: rgb(0xbb, 0x9a, 0xf7),
-                claude_marker: rgb(0xff, 0x9e, 0x64),
             },
             "catppuccin" => Self {
                 focus_border: rgb(0xf9, 0xe2, 0xaf),
@@ -368,7 +359,6 @@ impl Theme {
                 error: rgb(0xf3, 0x8b, 0xa8),
                 success: rgb(0xa6, 0xe3, 0xa1),
                 highlight: rgb(0xcb, 0xa6, 0xf7),
-                claude_marker: rgb(0xfa, 0xb3, 0x87),
             },
             "solarized" => Self {
                 focus_border: rgb(0xb5, 0x89, 0x00),
@@ -380,7 +370,6 @@ impl Theme {
                 error: rgb(0xdc, 0x32, 0x2f),
                 success: rgb(0x85, 0x99, 0x00),
                 highlight: rgb(0x6c, 0x71, 0xc4),
-                claude_marker: rgb(0xcb, 0x4b, 0x16),
             },
             "cyberdream" => Self {
                 focus_border: rgb(0xf1, 0xff, 0x5e),
@@ -392,7 +381,6 @@ impl Theme {
                 error: rgb(0xff, 0x6e, 0x5e),
                 success: rgb(0x5e, 0xff, 0x6c),
                 highlight: rgb(0xbd, 0x5e, 0xff),
-                claude_marker: rgb(0xff, 0xbd, 0x5e),
             },
             "carbonfox" => Self {
                 focus_border: rgb(0x08, 0xbd, 0xba),
@@ -404,7 +392,6 @@ impl Theme {
                 error: rgb(0xee, 0x53, 0x96),
                 success: rgb(0x25, 0xbe, 0x6a),
                 highlight: rgb(0xbe, 0x95, 0xff),
-                claude_marker: rgb(0xff, 0x7e, 0xb6),
             },
             other => {
                 warn!("unknown theme preset '{other}', using default");
@@ -419,14 +406,8 @@ impl Theme {
 /// unrecognised.
 pub fn parse_color(s: &str) -> Option<Color> {
     let t = s.trim();
-    if let Some(hex) = t.strip_prefix('#') {
-        if hex.len() == 6 {
-            let r = u8::from_str_radix(&hex[0..2], 16).ok()?;
-            let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
-            let b = u8::from_str_radix(&hex[4..6], 16).ok()?;
-            return Some(Color::Rgb(r, g, b));
-        }
-        return None;
+    if t.starts_with('#') {
+        return parse_hex_color(t);
     }
     if let Ok(idx) = t.parse::<u8>() {
         return Some(Color::Indexed(idx));
@@ -454,9 +435,27 @@ pub fn parse_color(s: &str) -> Option<Color> {
     Some(color)
 }
 
+/// Parse a truecolor hex code like `#ff8700` into [`Color::Rgb`]. Returns `None`
+/// for anything that is not a 6-digit `#rrggbb` string.
+pub fn parse_hex_color(s: &str) -> Option<Color> {
+    let hex = s.trim().strip_prefix('#')?;
+    if hex.len() != 6 {
+        return None;
+    }
+    let r = u8::from_str_radix(&hex[0..2], 16).ok()?;
+    let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
+    let b = u8::from_str_radix(&hex[4..6], 16).ok()?;
+    Some(Color::Rgb(r, g, b))
+}
+
 // =============================================================================
 // [hooks.claude] / [hooks.codex]
 // =============================================================================
+
+/// Default marker colour as a truecolor code (`#ff8700`, the orange of the
+/// classic xterm-256 slot 208). Marker colours are specified as hex colour
+/// codes in the config.
+const DEFAULT_MARKER_COLOR: Color = Color::Rgb(0xff, 0x87, 0x00);
 
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default)]
@@ -479,7 +478,7 @@ pub struct MarkerSet {
 
 impl Default for MarkerSet {
     fn default() -> Self {
-        let color = Color::Indexed(208);
+        let color = DEFAULT_MARKER_COLOR;
         Self {
             working: Marker::spinner(color),
             waiting: Marker::glyph("◆", color),
@@ -530,10 +529,12 @@ impl<'de> Deserialize<'de> for Marker {
             color: Option<String>,
         }
         let raw = Raw::deserialize(deserializer)?;
+        // Marker colours are given as a hex colour code, e.g. `color = "#ff8700"`.
         let color = match raw.color.as_deref() {
-            Some(c) => parse_color(c)
-                .ok_or_else(|| de::Error::custom(format!("invalid marker colour: {c}")))?,
-            None => Color::Indexed(208),
+            Some(c) => parse_hex_color(c).ok_or_else(|| {
+                de::Error::custom(format!("invalid marker colour {c:?}, expected a hex code like \"#ff8700\""))
+            })?,
+            None => DEFAULT_MARKER_COLOR,
         };
         Ok(Marker {
             animated: raw.glyph == "spinner",
@@ -626,6 +627,18 @@ impl KeyBindings {
             .find(|(_, specs)| specs.iter().any(|s| s.matches(key)))
             .map(|(action, _)| action)
     }
+
+    /// Human-readable label for an action's primary binding, e.g. `C-n` or `q`,
+    /// used to keep the on-screen hint bar in sync with the user's remaps.
+    /// Returns an empty string if the action has no binding.
+    pub fn label(&self, action: Action) -> String {
+        self.entries()
+            .into_iter()
+            .find(|(a, _)| *a == action)
+            .and_then(|(_, specs)| specs.first())
+            .map(KeySpec::label)
+            .unwrap_or_default()
+    }
 }
 
 /// A parsed key chord: a base key plus modifiers.
@@ -641,6 +654,40 @@ impl KeySpec {
     pub fn matches(&self, key: &KeyEvent) -> bool {
         let relevant = KeyModifiers::CONTROL | KeyModifiers::SHIFT | KeyModifiers::ALT;
         self.code == key.code && (key.modifiers & relevant) == self.mods
+    }
+
+    /// Render the chord back to a short label like `C-n`, `S-Tab`, `Space`, `q`.
+    /// Roughly the inverse of [`parse_key`].
+    pub fn label(&self) -> String {
+        let mut s = String::new();
+        if self.mods.contains(KeyModifiers::CONTROL) {
+            s.push_str("C-");
+        }
+        if self.mods.contains(KeyModifiers::ALT) {
+            s.push_str("A-");
+        }
+        if self.mods.contains(KeyModifiers::SHIFT) {
+            s.push_str("S-");
+        }
+        let base = match self.code {
+            KeyCode::Char(' ') => "Space".to_string(),
+            KeyCode::Char(c) => c.to_string(),
+            KeyCode::Esc => "Esc".to_string(),
+            KeyCode::Enter => "Enter".to_string(),
+            KeyCode::Tab => "Tab".to_string(),
+            KeyCode::BackTab => "BackTab".to_string(),
+            KeyCode::Up => "Up".to_string(),
+            KeyCode::Down => "Down".to_string(),
+            KeyCode::Left => "Left".to_string(),
+            KeyCode::Right => "Right".to_string(),
+            KeyCode::Home => "Home".to_string(),
+            KeyCode::End => "End".to_string(),
+            KeyCode::Backspace => "Backspace".to_string(),
+            KeyCode::Delete => "Delete".to_string(),
+            other => format!("{other:?}"),
+        };
+        s.push_str(&base);
+        s
     }
 }
 
@@ -749,6 +796,19 @@ mod tests {
         assert_eq!(parse_color("#ff8800"), Some(Color::Rgb(0xff, 0x88, 0x00)));
         assert_eq!(parse_color("notacolor"), None);
         assert_eq!(parse_color("#xyz"), None);
+        // Hex-only parser used for marker colours.
+        assert_eq!(parse_hex_color("#ff8700"), Some(Color::Rgb(0xff, 0x87, 0x00)));
+        assert_eq!(parse_hex_color("red"), None);
+        assert_eq!(parse_hex_color("208"), None);
+    }
+
+    #[test]
+    fn marker_color_must_be_hex() {
+        // A colour name is rejected for marker colours (hex codes only).
+        let err = toml::from_str::<Config>(
+            "[hooks.claude]\nworking = { glyph = \"x\", color = \"red\" }\n",
+        );
+        assert!(err.is_err(), "non-hex marker colour should be rejected");
     }
 
     #[test]
@@ -787,7 +847,7 @@ mod tests {
     #[test]
     fn partial_config_merges_with_defaults() {
         let cfg: Config = toml::from_str(
-            r#"
+            r##"
             [preview]
             interval = 500
 
@@ -795,8 +855,8 @@ mod tests {
             quit = "x"
 
             [hooks.claude]
-            done = { glyph = "DONE", color = "green" }
-        "#,
+            done = { glyph = "DONE", color = "#00ff00" }
+        "##,
         )
         .unwrap();
         assert_eq!(cfg.preview.interval, Some(500));
@@ -804,9 +864,9 @@ mod tests {
         assert_eq!(cfg.keybindings.quit, vec![key('x')]);
         // ...while untouched bindings keep their defaults.
         assert_eq!(cfg.keybindings.refresh, vec![key('r')]);
-        // Overridden marker, and a default sibling marker.
+        // Overridden marker (hex colour), and a default sibling marker.
         assert_eq!(cfg.hooks.claude.done.glyph, "DONE");
-        assert_eq!(cfg.hooks.claude.done.color, Color::Green);
+        assert_eq!(cfg.hooks.claude.done.color, Color::Rgb(0x00, 0xff, 0x00));
         assert_eq!(cfg.hooks.claude.waiting.glyph, "◆");
     }
 
@@ -838,13 +898,14 @@ mod tests {
         // Override applied.
         assert_eq!(theme.accent, Color::Rgb(0x12, 0x34, 0x56));
         // Preset value retained for a non-overridden role.
-        assert_eq!(theme.claude_marker, Color::Rgb(0xff, 0xb8, 0x6c));
+        assert_eq!(theme.success, Color::Rgb(0x50, 0xfa, 0x7b));
     }
 
     #[test]
     fn unknown_preset_falls_back_to_default() {
         let theme = Theme::preset("does-not-exist");
-        assert_eq!(theme.claude_marker, Color::Indexed(208));
+        // Falls back to the `default` preset's palette.
+        assert_eq!(theme.accent, Color::Cyan);
     }
 
     #[test]
@@ -863,10 +924,12 @@ mod tests {
         // The example we ship must always parse against the current schema.
         let example = include_str!("../docs/config.example.toml");
         let cfg: Config = toml::from_str(example).expect("example config must parse");
-        // Spot-check a couple of representative values.
-        assert_eq!(cfg.preview.interval, Some(300));
-        assert_eq!(cfg.theme.preset, "default");
+        // Spot-check representative values without pinning the exact interval
+        // (the example may tweak it).
+        assert!(cfg.preview.interval.is_some());
         assert!(cfg.hooks.claude.working.animated);
+        // Marker colours in the example are hex codes.
+        assert_eq!(cfg.hooks.claude.waiting.color, Color::Rgb(0xff, 0x87, 0x00));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod actor;
 mod app;
 mod cli;
+mod config;
 mod group;
 mod hook;
 mod ui;
@@ -21,6 +22,10 @@ use tracing_subscriber::{EnvFilter, fmt::time};
 use actor::{RefreshActor, RefreshControl, TmuxActor, TmuxCommand, TmuxResponse, UIActor, UIEvent};
 use app::UIState;
 use cli::{Cli, Command, HookAction};
+use config::Config;
+
+/// Fallback preview interval (ms) when neither the CLI flag nor the config sets one.
+const DEFAULT_INTERVAL_MS: u64 = 300;
 
 // =============================================================================
 // Main
@@ -43,6 +48,14 @@ async fn main() -> Result<()> {
             },
         };
     }
+
+    // Load user config (best-effort): CLI --config > XDG config.toml > defaults.
+    let config = Config::load(cmd.config.as_deref());
+    // CLI --interval wins over the config, which wins over the built-in default.
+    let interval_ms = cmd
+        .interval
+        .or(config.preview.interval)
+        .unwrap_or(DEFAULT_INTERVAL_MS);
 
     let project_dir =
         ProjectDirs::from("dev", "tkcd", "tmux-deck").expect("cannot determine project directory");
@@ -67,7 +80,7 @@ async fn main() -> Result<()> {
     io::stdout().execute(EnterAlternateScreen)?;
     let terminal = Terminal::new(CrosstermBackend::new(io::stdout()))?;
 
-    let result = run_app(terminal, cmd.interval).await;
+    let result = run_app(terminal, config, interval_ms).await;
 
     disable_raw_mode()?;
     io::stdout().execute(LeaveAlternateScreen)?;
@@ -75,7 +88,11 @@ async fn main() -> Result<()> {
     result
 }
 
-async fn run_app(terminal: Terminal<CrosstermBackend<io::Stdout>>, interval_ms: u64) -> Result<()> {
+async fn run_app(
+    terminal: Terminal<CrosstermBackend<io::Stdout>>,
+    config: Config,
+    interval_ms: u64,
+) -> Result<()> {
     // Create channels.
     // tmux_cmd_*: high-priority user-initiated commands.
     // tmux_capture_*: low-priority periodic capture-pane requests.
@@ -88,7 +105,7 @@ async fn run_app(terminal: Terminal<CrosstermBackend<io::Stdout>>, interval_ms: 
     let refresh_control = RefreshControl::new();
 
     // Initialize UIState
-    let state = UIState::new(interval_ms);
+    let state = UIState::new(config);
     let interval = Duration::from_millis(interval_ms);
 
     // Create actors

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -7,7 +7,7 @@ use crate::app::{
     ClaudeState, Focus, InputMode, PopupMode, SessionRow, TmuxPane, TmuxWindow, UIState,
     UNGROUPED_LABEL, ViewMode,
 };
-use crate::config::{MarkerSet, Theme};
+use crate::config::{Action, MarkerSet, Theme};
 
 /// Braille "dots" spinner frames (cli-spinners `dots`). Rendered for a marker
 /// configured as `"spinner"` (the default `Working` Claude state) so it
@@ -397,26 +397,29 @@ fn render_tree_status_bar(frame: &mut Frame, state: &UIState, area: Rect) {
             Style::default().fg(theme.error),
         )])
     } else {
+        let kb = &state.keybindings;
+        // `j/k`, `Tab`, `za` and `Space×2` are fixed (not remappable); the rest
+        // reflect the user's key bindings so the hint bar always stays accurate.
         Line::from(vec![
             Span::styled("j/k", Style::default().fg(theme.focus_border)),
             Span::raw(":move "),
             Span::styled("Tab", Style::default().fg(theme.focus_border)),
             Span::raw(":focus "),
-            Span::styled("s", Style::default().fg(theme.focus_border)),
+            Span::styled(kb.label(Action::Sort), Style::default().fg(theme.focus_border)),
             Span::raw(":sort "),
-            Span::styled("g", Style::default().fg(theme.focus_border)),
+            Span::styled(kb.label(Action::Group), Style::default().fg(theme.focus_border)),
             Span::raw(":group "),
             Span::styled("za", Style::default().fg(theme.focus_border)),
             Span::raw(":fold "),
             Span::styled("Space×2", Style::default().fg(theme.highlight)),
             Span::raw(":multi "),
-            Span::styled("C-n", Style::default().fg(theme.success)),
+            Span::styled(kb.label(Action::NewSession), Style::default().fg(theme.success)),
             Span::raw(":new "),
-            Span::styled("C-r", Style::default().fg(theme.success)),
+            Span::styled(kb.label(Action::RenameSession), Style::default().fg(theme.success)),
             Span::raw(":rename "),
-            Span::styled("C-x", Style::default().fg(theme.error)),
+            Span::styled(kb.label(Action::KillSession), Style::default().fg(theme.error)),
             Span::raw(":kill "),
-            Span::styled("q", Style::default().fg(theme.focus_border)),
+            Span::styled(kb.label(Action::Quit), Style::default().fg(theme.focus_border)),
             Span::raw(":quit"),
         ])
     };
@@ -550,6 +553,7 @@ fn render_multi_preview(frame: &mut Frame, state: &UIState) {
             .get_multi_selected_target()
             .unwrap_or_else(|| "None".to_string());
 
+        let kb = &state.keybindings;
         Line::from(vec![
             Span::styled("h/l", Style::default().fg(theme.focus_border)),
             Span::raw(":session "),
@@ -557,13 +561,13 @@ fn render_multi_preview(frame: &mut Frame, state: &UIState) {
             Span::raw(":window "),
             Span::styled("Space×2", Style::default().fg(theme.highlight)),
             Span::raw(":tree "),
-            Span::styled("C-n", Style::default().fg(theme.success)),
+            Span::styled(kb.label(Action::NewSession), Style::default().fg(theme.success)),
             Span::raw(":new "),
-            Span::styled("C-r", Style::default().fg(theme.success)),
+            Span::styled(kb.label(Action::RenameSession), Style::default().fg(theme.success)),
             Span::raw(":rename "),
-            Span::styled("C-x", Style::default().fg(theme.error)),
+            Span::styled(kb.label(Action::KillSession), Style::default().fg(theme.error)),
             Span::raw(":kill "),
-            Span::styled("q", Style::default().fg(theme.focus_border)),
+            Span::styled(kb.label(Action::Quit), Style::default().fg(theme.focus_border)),
             Span::raw(":quit "),
             Span::raw("| "),
             Span::styled(

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -7,18 +7,11 @@ use crate::app::{
     ClaudeState, Focus, InputMode, PopupMode, SessionRow, TmuxPane, TmuxWindow, UIState,
     UNGROUPED_LABEL, ViewMode,
 };
+use crate::config::{MarkerSet, Theme};
 
-/// Single colour used for every Claude marker. States are distinguished by
-/// glyph *shape*, not colour, so the markers stay legible regardless of the
-/// terminal palette or colour-blindness. Color::Indexed(208) is the standard
-/// 256-color "Orange1" slot, which renders consistently across terminals that
-/// do not honour truecolor.
-const CLAUDE_MARKER_COLOR: Color = Color::Indexed(208);
-/// Marker shown for a claude process when no hook state is known.
-const CLAUDE_MARKER: &str = "●";
-
-/// Braille "dots" spinner frames (cli-spinners `dots`). Rendered for the
-/// `Working` Claude state so the marker visibly animates.
+/// Braille "dots" spinner frames (cli-spinners `dots`). Rendered for a marker
+/// configured as `"spinner"` (the default `Working` Claude state) so it
+/// visibly animates.
 const SPINNER_FRAMES: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 /// Milliseconds each spinner frame is shown.
 const SPINNER_FRAME_MS: u128 = 80;
@@ -38,31 +31,40 @@ fn spinner_frame() -> &'static str {
 }
 
 /// The marker glyph + colour to show for a node, given its hook state and
-/// whether a claude process was detected. States are distinguished by shape
-/// (the colour is always the same); hook state wins, otherwise we fall back to
-/// the plain "claude is running" dot so behaviour is unchanged when hooks are
-/// not installed. Returns `None` when there is nothing to show.
-fn claude_marker(state: Option<ClaudeState>, has_claude: bool) -> Option<(&'static str, Color)> {
-    let sym = match state {
-        Some(ClaudeState::Working) => spinner_frame(),
-        Some(ClaudeState::Waiting) => "◆",
-        Some(ClaudeState::Done) => "✓",
-        Some(ClaudeState::Error) => "✗",
-        None if has_claude => CLAUDE_MARKER,
+/// whether a claude process was detected. The glyph and colour come from the
+/// user-configurable [`MarkerSet`]; a marker configured as `"spinner"` animates.
+/// Hook state wins, otherwise we fall back to the plain "claude is running"
+/// marker so behaviour is unchanged when hooks are not installed. Returns
+/// `None` when there is nothing to show.
+fn claude_marker(
+    markers: &MarkerSet,
+    state: Option<ClaudeState>,
+    has_claude: bool,
+) -> Option<(String, Color)> {
+    let marker = match state {
+        Some(ClaudeState::Working) => &markers.working,
+        Some(ClaudeState::Waiting) => &markers.waiting,
+        Some(ClaudeState::Done) => &markers.done,
+        Some(ClaudeState::Error) => &markers.error,
+        None if has_claude => &markers.running,
         None => return None,
     };
-    Some((sym, CLAUDE_MARKER_COLOR))
+    let glyph = if marker.animated {
+        spinner_frame().to_string()
+    } else {
+        marker.glyph.clone()
+    };
+    Some((glyph, marker.color))
 }
 
 /// Border accent colour for a node that is running claude (any state). The
-/// border only signals presence — state is conveyed by the marker shape — so a
-/// single colour is used throughout.
-fn claude_border_color(state: Option<ClaudeState>, has_claude: bool) -> Option<Color> {
-    if state.is_some() || has_claude {
-        Some(CLAUDE_MARKER_COLOR)
-    } else {
-        None
-    }
+/// border only signals presence; it reuses the marker's colour for that state.
+fn claude_border_color(
+    markers: &MarkerSet,
+    state: Option<ClaudeState>,
+    has_claude: bool,
+) -> Option<Color> {
+    claude_marker(markers, state, has_claude).map(|(_, color)| color)
 }
 
 // =============================================================================
@@ -102,17 +104,22 @@ fn render_tree_view(frame: &mut Frame, state: &mut UIState) {
     let area = frame.area();
 
     // Main layout: left panel (lists) | right panel (preview)
-    let main_chunks =
-        Layout::horizontal([Constraint::Percentage(30), Constraint::Percentage(70)]).split(area);
+    let left_width = state.layout.session_panel_width.min(100);
+    let main_chunks = Layout::horizontal([
+        Constraint::Percentage(left_width),
+        Constraint::Percentage(100 - left_width),
+    ])
+    .split(area);
 
     let left_panel = main_chunks[0];
     let right_panel = main_chunks[1];
 
     // Left panel: Sessions | Windows | Panes (vertical stack)
+    let [s, w, p] = state.layout.tree_split;
     let left_chunks = Layout::vertical([
-        Constraint::Percentage(30),
-        Constraint::Percentage(35),
-        Constraint::Percentage(35),
+        Constraint::Percentage(s),
+        Constraint::Percentage(w),
+        Constraint::Percentage(p),
     ])
     .split(left_panel);
 
@@ -127,11 +134,12 @@ fn render_tree_view(frame: &mut Frame, state: &mut UIState) {
 }
 
 fn render_sessions_list(frame: &mut Frame, state: &mut UIState, area: Rect) {
+    let theme = state.theme;
     let is_focused = state.focus == Focus::Sessions;
     let border_style = if is_focused {
-        Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)
+        Style::default().fg(theme.focus_border).add_modifier(Modifier::BOLD)
     } else {
-        Style::default().fg(Color::DarkGray)
+        Style::default().fg(theme.unfocus_border)
     };
 
     // Grouping turns the flat session list into a list of rows that may also
@@ -168,10 +176,10 @@ fn render_sessions_list(frame: &mut Frame, state: &mut UIState, area: Rect) {
                     selected_row = Some(row_idx);
                 }
                 let mut style = Style::default()
-                    .fg(Color::Cyan)
+                    .fg(theme.accent)
                     .add_modifier(Modifier::BOLD);
                 if is_selected {
-                    style = style.bg(Color::DarkGray).fg(Color::White);
+                    style = style.bg(theme.selection_bg).fg(theme.selection_fg);
                 }
                 items.push(ListItem::new(Line::from(vec![Span::styled(
                     format!("{} {} ({})", arrow, label, count),
@@ -184,7 +192,7 @@ fn render_sessions_list(frame: &mut Frame, state: &mut UIState, area: Rect) {
                     selected_row = Some(row_idx);
                 }
                 let style = if *index == state.selected_session {
-                    Style::default().bg(Color::DarkGray).fg(Color::White)
+                    Style::default().bg(theme.selection_bg).fg(theme.selection_fg)
                 } else {
                     Style::default()
                 };
@@ -195,7 +203,7 @@ fn render_sessions_list(frame: &mut Frame, state: &mut UIState, area: Rect) {
                     session.name.clone()
                 })];
                 if let Some((sym, color)) =
-                    claude_marker(session.claude_state, session.has_claude)
+                    claude_marker(&state.hooks.claude, session.claude_state, session.has_claude)
                 {
                     spans.push(Span::styled(
                         format!(" {}", sym),
@@ -229,11 +237,12 @@ fn render_sessions_list(frame: &mut Frame, state: &mut UIState, area: Rect) {
 }
 
 fn render_windows_list(frame: &mut Frame, state: &mut UIState, area: Rect) {
+    let theme = state.theme;
     let is_focused = state.focus == Focus::Windows;
     let border_style = if is_focused {
-        Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)
+        Style::default().fg(theme.focus_border).add_modifier(Modifier::BOLD)
     } else {
-        Style::default().fg(Color::DarkGray)
+        Style::default().fg(theme.unfocus_border)
     };
 
     let empty_windows: Vec<TmuxWindow> = Vec::new();
@@ -248,12 +257,14 @@ fn render_windows_list(frame: &mut Frame, state: &mut UIState, area: Rect) {
         .enumerate()
         .map(|(i, window)| {
             let style = if i == state.selected_window {
-                Style::default().bg(Color::DarkGray).fg(Color::White)
+                Style::default().bg(theme.selection_bg).fg(theme.selection_fg)
             } else {
                 Style::default()
             };
             let mut spans = vec![Span::raw(format!("{}:{}", window.index, window.name))];
-            if let Some((sym, color)) = claude_marker(window.claude_state, window.has_claude) {
+            if let Some((sym, color)) =
+                claude_marker(&state.hooks.claude, window.claude_state, window.has_claude)
+            {
                 spans.push(Span::styled(
                     format!(" {}", sym),
                     Style::default().fg(color),
@@ -283,11 +294,12 @@ fn render_windows_list(frame: &mut Frame, state: &mut UIState, area: Rect) {
 }
 
 fn render_panes_list(frame: &mut Frame, state: &mut UIState, area: Rect) {
+    let theme = state.theme;
     let is_focused = state.focus == Focus::Panes;
     let border_style = if is_focused {
-        Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)
+        Style::default().fg(theme.focus_border).add_modifier(Modifier::BOLD)
     } else {
-        Style::default().fg(Color::DarkGray)
+        Style::default().fg(theme.unfocus_border)
     };
 
     let empty_panes: Vec<TmuxPane> = Vec::new();
@@ -303,7 +315,7 @@ fn render_panes_list(frame: &mut Frame, state: &mut UIState, area: Rect) {
         .enumerate()
         .map(|(i, pane)| {
             let style = if i == state.selected_pane {
-                Style::default().bg(Color::DarkGray).fg(Color::White)
+                Style::default().bg(theme.selection_bg).fg(theme.selection_fg)
             } else {
                 Style::default()
             };
@@ -311,7 +323,9 @@ fn render_panes_list(frame: &mut Frame, state: &mut UIState, area: Rect) {
                 "{}:{} [{}]",
                 pane.index, pane.id, pane.current_command
             ))];
-            if let Some((sym, color)) = claude_marker(pane.claude_state, pane.has_claude) {
+            if let Some((sym, color)) =
+                claude_marker(&state.hooks.claude, pane.claude_state, pane.has_claude)
+            {
                 spans.push(Span::styled(
                     format!(" {}", sym),
                     Style::default().fg(color),
@@ -349,7 +363,7 @@ fn render_pane_preview_tree(frame: &mut Frame, state: &UIState, area: Rect) {
 
     let block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Cyan))
+        .border_style(Style::default().fg(state.theme.accent))
         .title(title);
 
     let inner = block.inner(area);
@@ -376,38 +390,39 @@ fn render_pane_preview_tree(frame: &mut Frame, state: &UIState, area: Rect) {
 }
 
 fn render_tree_status_bar(frame: &mut Frame, state: &UIState, area: Rect) {
+    let theme = state.theme;
     let status_text = if let Some(ref err) = state.last_error {
         Line::from(vec![Span::styled(
             format!(" Error: {} ", err),
-            Style::default().fg(Color::Red),
+            Style::default().fg(theme.error),
         )])
     } else {
         Line::from(vec![
-            Span::styled("j/k", Style::default().fg(Color::Yellow)),
+            Span::styled("j/k", Style::default().fg(theme.focus_border)),
             Span::raw(":move "),
-            Span::styled("Tab", Style::default().fg(Color::Yellow)),
+            Span::styled("Tab", Style::default().fg(theme.focus_border)),
             Span::raw(":focus "),
-            Span::styled("s", Style::default().fg(Color::Yellow)),
+            Span::styled("s", Style::default().fg(theme.focus_border)),
             Span::raw(":sort "),
-            Span::styled("g", Style::default().fg(Color::Yellow)),
+            Span::styled("g", Style::default().fg(theme.focus_border)),
             Span::raw(":group "),
-            Span::styled("za", Style::default().fg(Color::Yellow)),
+            Span::styled("za", Style::default().fg(theme.focus_border)),
             Span::raw(":fold "),
-            Span::styled("Space×2", Style::default().fg(Color::Magenta)),
+            Span::styled("Space×2", Style::default().fg(theme.highlight)),
             Span::raw(":multi "),
-            Span::styled("C-n", Style::default().fg(Color::Green)),
+            Span::styled("C-n", Style::default().fg(theme.success)),
             Span::raw(":new "),
-            Span::styled("C-r", Style::default().fg(Color::Green)),
+            Span::styled("C-r", Style::default().fg(theme.success)),
             Span::raw(":rename "),
-            Span::styled("C-x", Style::default().fg(Color::Red)),
+            Span::styled("C-x", Style::default().fg(theme.error)),
             Span::raw(":kill "),
-            Span::styled("q", Style::default().fg(Color::Yellow)),
+            Span::styled("q", Style::default().fg(theme.focus_border)),
             Span::raw(":quit"),
         ])
     };
 
     frame.render_widget(
-        Paragraph::new(status_text).style(Style::default().bg(Color::DarkGray)),
+        Paragraph::new(status_text).style(Style::default().bg(theme.status_bar_bg)),
         area,
     );
 }
@@ -418,6 +433,7 @@ fn render_tree_status_bar(frame: &mut Frame, state: &UIState, area: Rect) {
 
 fn render_multi_preview(frame: &mut Frame, state: &UIState) {
     let area = frame.area();
+    let theme = state.theme;
 
     let main_chunks = Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).split(area);
 
@@ -430,20 +446,20 @@ fn render_multi_preview(frame: &mut Frame, state: &UIState) {
             .title(" No sessions found ");
         frame.render_widget(block, preview_area);
     } else {
-        // Create horizontal layout for sessions
-        // Selected session gets 80%, others share 20%
+        // Create horizontal layout for sessions: the selected session gets
+        // `multi_selected_ratio`%, the rest share what remains.
+        let selected_ratio = state.layout.multi_selected_ratio.min(100);
         let session_constraints: Vec<Constraint> = if state.sessions.len() == 1 {
             vec![Constraint::Percentage(100)]
         } else {
             let other_count = state.sessions.len() - 1;
-            // Each non-selected session gets an equal share of 20%
-            let other_percentage = 30 / other_count as u16;
+            let other_percentage = (100 - selected_ratio) / other_count as u16;
             state.sessions
                 .iter()
                 .enumerate()
                 .map(|(idx, _)| {
                     if idx == state.multi_session {
-                        Constraint::Percentage(70)
+                        Constraint::Percentage(selected_ratio)
                     } else {
                         Constraint::Percentage(other_percentage.max(1))
                     }
@@ -462,17 +478,19 @@ fn render_multi_preview(frame: &mut Frame, state: &UIState) {
             // their Claude state colour unless they are the currently selected
             // session (selection colour wins so focus is never lost).
             let session_border_style = if is_selected_session {
-                Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)
+                Style::default().fg(theme.focus_border).add_modifier(Modifier::BOLD)
             } else if let Some(color) =
-                claude_border_color(session.claude_state, session.has_claude)
+                claude_border_color(&state.hooks.claude, session.claude_state, session.has_claude)
             {
                 Style::default().fg(color)
             } else {
-                Style::default().fg(Color::DarkGray)
+                Style::default().fg(theme.unfocus_border)
             };
 
             let mut title_spans = vec![Span::raw(format!(" {} ", session.name))];
-            if let Some((sym, color)) = claude_marker(session.claude_state, session.has_claude) {
+            if let Some((sym, color)) =
+                claude_marker(&state.hooks.claude, session.claude_state, session.has_claude)
+            {
                 title_spans.push(Span::styled(
                     format!("{} ", sym),
                     Style::default().fg(color),
@@ -489,7 +507,7 @@ fn render_multi_preview(frame: &mut Frame, state: &UIState) {
 
             if session.windows.is_empty() {
                 let no_windows = Paragraph::new("No windows")
-                    .style(Style::default().fg(Color::DarkGray));
+                    .style(Style::default().fg(theme.unfocus_border));
                 frame.render_widget(no_windows, inner_area);
                 continue;
             }
@@ -509,7 +527,14 @@ fn render_multi_preview(frame: &mut Frame, state: &UIState) {
                 let is_selected_window =
                     is_selected_session && window_idx == state.multi_window;
 
-                render_window_preview(frame, window, *window_area, is_selected_window);
+                render_window_preview(
+                    frame,
+                    &state.theme,
+                    &state.hooks.claude,
+                    window,
+                    *window_area,
+                    is_selected_window,
+                );
             }
         }
     }
@@ -518,7 +543,7 @@ fn render_multi_preview(frame: &mut Frame, state: &UIState) {
     let status_text = if let Some(ref err) = state.last_error {
         Line::from(vec![Span::styled(
             format!(" Error: {} ", err),
-            Style::default().fg(Color::Red),
+            Style::default().fg(theme.error),
         )])
     } else {
         let selected_info = state
@@ -526,43 +551,50 @@ fn render_multi_preview(frame: &mut Frame, state: &UIState) {
             .unwrap_or_else(|| "None".to_string());
 
         Line::from(vec![
-            Span::styled("h/l", Style::default().fg(Color::Yellow)),
+            Span::styled("h/l", Style::default().fg(theme.focus_border)),
             Span::raw(":session "),
-            Span::styled("j/k", Style::default().fg(Color::Yellow)),
+            Span::styled("j/k", Style::default().fg(theme.focus_border)),
             Span::raw(":window "),
-            Span::styled("Space×2", Style::default().fg(Color::Magenta)),
+            Span::styled("Space×2", Style::default().fg(theme.highlight)),
             Span::raw(":tree "),
-            Span::styled("C-n", Style::default().fg(Color::Green)),
+            Span::styled("C-n", Style::default().fg(theme.success)),
             Span::raw(":new "),
-            Span::styled("C-r", Style::default().fg(Color::Green)),
+            Span::styled("C-r", Style::default().fg(theme.success)),
             Span::raw(":rename "),
-            Span::styled("C-x", Style::default().fg(Color::Red)),
+            Span::styled("C-x", Style::default().fg(theme.error)),
             Span::raw(":kill "),
-            Span::styled("q", Style::default().fg(Color::Yellow)),
+            Span::styled("q", Style::default().fg(theme.focus_border)),
             Span::raw(":quit "),
             Span::raw("| "),
             Span::styled(
                 format!("Sel:{}", selected_info),
-                Style::default().fg(Color::Cyan),
+                Style::default().fg(theme.accent),
             ),
         ])
     };
 
     frame.render_widget(
-        Paragraph::new(status_text).style(Style::default().bg(Color::DarkGray)),
+        Paragraph::new(status_text).style(Style::default().bg(theme.status_bar_bg)),
         status_area,
     );
 }
 
-fn render_window_preview(frame: &mut Frame, window: &TmuxWindow, area: Rect, is_selected: bool) {
+fn render_window_preview(
+    frame: &mut Frame,
+    theme: &Theme,
+    markers: &MarkerSet,
+    window: &TmuxWindow,
+    area: Rect,
+    is_selected: bool,
+) {
     let border_style = if is_selected {
         Style::default()
-            .fg(Color::Cyan)
+            .fg(theme.accent)
             .add_modifier(Modifier::BOLD)
-    } else if let Some(color) = claude_border_color(window.claude_state, window.has_claude) {
+    } else if let Some(color) = claude_border_color(markers, window.claude_state, window.has_claude) {
         Style::default().fg(color)
     } else {
-        Style::default().fg(Color::DarkGray)
+        Style::default().fg(theme.unfocus_border)
     };
 
     let cmd = window
@@ -574,7 +606,7 @@ fn render_window_preview(frame: &mut Frame, window: &TmuxWindow, area: Rect, is_
         " {}:{} [{}] ",
         window.index, window.name, cmd
     ))];
-    if let Some((sym, color)) = claude_marker(window.claude_state, window.has_claude) {
+    if let Some((sym, color)) = claude_marker(markers, window.claude_state, window.has_claude) {
         title_spans.push(Span::styled(
             format!("{} ", sym),
             Style::default().fg(color),
@@ -615,7 +647,7 @@ fn render_input_popup(frame: &mut Frame, state: &UIState, area: Rect) {
 
     let block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Cyan))
+        .border_style(Style::default().fg(state.theme.accent))
         .title(format!(" Send to: {} ", target_info))
         .title_bottom(Line::from(" Enter:send | Esc:cancel ").centered());
 
@@ -686,7 +718,7 @@ fn render_session_name_popup(frame: &mut Frame, state: &UIState, title: &str, la
 
     let block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Cyan))
+        .border_style(Style::default().fg(state.theme.accent))
         .title(format!(" {} ", title))
         .title_bottom(Line::from(" Enter:confirm | Esc:cancel ").centered());
 
@@ -755,11 +787,11 @@ fn render_group_select_popup(frame: &mut Frame, state: &UIState) {
     let ungrouped_label = "(Ungrouped)";
     items.push(ListItem::new(Line::from(Span::styled(
         ungrouped_label,
-        Style::default().fg(Color::DarkGray),
+        Style::default().fg(state.theme.unfocus_border),
     ))));
     items.push(ListItem::new(Line::from(Span::styled(
         "+ New group…",
-        Style::default().fg(Color::Green),
+        Style::default().fg(state.theme.success),
     ))));
 
     // Size the popup to the content, clamped so it always fits on screen.
@@ -782,7 +814,7 @@ fn render_group_select_popup(frame: &mut Frame, state: &UIState) {
 
     let block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Cyan))
+        .border_style(Style::default().fg(state.theme.accent))
         .title(format!(" Group: {} ", session_name))
         .title_bottom(Line::from(" ↑↓:select | Enter:confirm | Esc:cancel ").centered());
 
@@ -794,7 +826,7 @@ fn render_group_select_popup(frame: &mut Frame, state: &UIState) {
 
     let list = List::new(items).highlight_style(
         Style::default()
-            .bg(Color::Cyan)
+            .bg(state.theme.accent)
             .fg(Color::Black)
             .add_modifier(Modifier::BOLD),
     );
@@ -827,7 +859,7 @@ fn render_confirm_kill_popup(frame: &mut Frame, state: &UIState) {
 
     let block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Red))
+        .border_style(Style::default().fg(state.theme.error))
         .title(" Kill Session ")
         .title_bottom(Line::from(" Enter:confirm | Esc:cancel ").centered());
 
@@ -856,15 +888,15 @@ fn render_confirm_kill_popup(frame: &mut Frame, state: &UIState) {
     .split(button_area);
 
     let yes_style = if state.confirm_yes_selected {
-        Style::default().fg(Color::Black).bg(Color::Red).add_modifier(Modifier::BOLD)
+        Style::default().fg(Color::Black).bg(state.theme.error).add_modifier(Modifier::BOLD)
     } else {
-        Style::default().fg(Color::DarkGray)
+        Style::default().fg(state.theme.unfocus_border)
     };
 
     let no_style = if !state.confirm_yes_selected {
-        Style::default().fg(Color::Black).bg(Color::Green).add_modifier(Modifier::BOLD)
+        Style::default().fg(Color::Black).bg(state.theme.success).add_modifier(Modifier::BOLD)
     } else {
-        Style::default().fg(Color::DarkGray)
+        Style::default().fg(state.theme.unfocus_border)
     };
 
     let yes_button = Paragraph::new(" [Y]es ")


### PR DESCRIPTION
## 概要

tmux-deck に XDG ベースの TOML 設定ファイル機能を追加します。`$XDG_CONFIG_HOME/tmux-deck/config.toml`（または `--config <path>`）を読み込み、無ければ従来どおりの **zero-config** 動作、壊れていれば警告ログを出して既定値にフォールバックします（`GroupStore` と同方針で起動を妨げません）。

## 設定項目

| セクション | 内容 |
| --- | --- |
| `[preview]` | `interval`（CLI `--interval` > config > 既定300ms） |
| `[theme]` | プリセット10種 + `[theme.colors]` 個別上書き |
| `[keybindings]` | quit/refresh/sort/group/input/enter/new/rename/kill を再マップ |
| `[hooks.claude]` | 状態別マーカー（グリフ + **hexカラーコード**、`"spinner"`でアニメ） |
| `[hooks.codex]` | 将来用（定義・パースのみ、UI未消費） |
| `[layout]` | 左パネル幅・tree分割比・MultiPreview選択比 |
| `[behavior]` | 起動ビュー・既定ソート・Space二度押し時間・切替後終了 |

テーマプリセット: \`default\` / \`monochrome\` / \`dracula\` / \`nord\` / \`gruvbox\` / \`tokyonight\` / \`catppuccin\` / \`solarized\` / \`cyberdream\` / \`carbonfox\`。

## 主な実装

- **新規 `src/config.rs`**: hex色パース（`parse_hex_color`）/キーパース（`KeySpec`・`parse_key`）/テーマ解決/`Config::load`。
- **キーバインド**: `KeyBindings::action_for` でキー→アクション解決。`za` フォールドと Space×2 のコードは固定。ステータスバーの表記（`C-n:new` 等）は `KeySpec::label` 経由で現在のバインドに追従。
- **マーカー色**: `[hooks.*]` は hexコードのみ（既定 `#ff8700`）。未使用となったテーマ `claude_marker` ロールは廃止。
- **`[behavior]`**: `exit_on_switch` でEnter切替後に終了するか制御。
- `docs/config.example.toml`（全項目コメント付き）と README の Configuration 節を追加。

## 検証

- \`cargo test\`: 40件すべて通過（色/キーパース、テーマ解決、hex専用パースと非hex拒否、同梱例のパース、入力文字数制限等）
- \`cargo clippy\`: 警告なし
- 実機（tmux PTY）スモーク: zero-config回帰、不正config時フォールバック、キー再マップのステータスバー反映、hexマーカー色入りconfigでの起動/終了を確認

## 備考

- `origin/main`（v0.1.11: ポップアップ入力の単一行化・30文字上限・マルチバイト対策）をマージ済み。入力処理と本PRのキーバインド刷新は別経路で両立。
- `Cargo.toml` の version は `0.0.0` のまま（指示により据え置き）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)