### PR TITLE
feat(ui): Claude fleet dashboard view (#21, completes #18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Monitoring multi session Realtime preview.
 - 📄 Easy management Windows and Panes between Sessions
 - 👀 Realtime Preview
 - 🤖 Claude Code status markers (working / waiting / done) driven by hooks
+- 🛰️ Claude fleet dashboard (`d`): every Claude pane sorted by attention, jump with `Enter`
 - ⚙️ Easy Configure
 
 # Quick Start
@@ -136,7 +137,7 @@ The remappable actions and their defaults:
 | `refresh` | `r`        | `rename_session` | `C-r`   |
 | `sort`    | `s`        | `kill_session`   | `C-x`   |
 | `group`   | `g`        | `enter`          | `Enter` |
-| `input`   | `i`        |                  |         |
+| `input`   | `i`        | `dashboard`      | `d`     |
 
 A binding is one key string or a list. Modifiers are joined with `-` (`C`/`Ctrl`,
 `S`/`Shift`, `A`/`M`/`Alt`); keys are a single character or a name (`Esc`, `Tab`,

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -61,6 +61,7 @@ enter          = "Enter"
 new_session    = "C-n"
 rename_session = "C-r"
 kill_session   = "C-x"
+dashboard      = "d"            # toggle the Claude fleet dashboard
 
 # -----------------------------------------------------------------------------
 # Markers shown for hook-driven agent states. Each marker has a `glyph` and a

--- a/src/actor/ui_actor.rs
+++ b/src/actor/ui_actor.rs
@@ -379,6 +379,7 @@ impl UIActor {
                         }
                     }
                 }
+                Action::Dashboard => self.state.toggle_dashboard(),
                 // Context-gated actions whose gate is not satisfied fall through
                 // to navigation so the key is not swallowed.
                 Action::Sort | Action::Group => {
@@ -448,6 +449,11 @@ impl UIActor {
                 KeyCode::Down | KeyCode::Char('j') => self.state.multi_move_down(),
                 KeyCode::Left | KeyCode::Char('h') => self.state.multi_move_left(),
                 KeyCode::Right | KeyCode::Char('l') => self.state.multi_move_right(),
+                _ => {}
+            },
+            ViewMode::Dashboard => match code {
+                KeyCode::Up | KeyCode::Char('k') => self.state.dashboard_move_up(),
+                KeyCode::Down | KeyCode::Char('j') => self.state.dashboard_move_down(),
                 _ => {}
             },
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -115,12 +115,9 @@ pub struct TmuxPane {
     pub claude_state: Option<ClaudeState>,
     /// One-line summary of what Claude is currently doing (e.g. `Edit: src/app.rs`),
     /// sourced from the hook activity digest. `None` when unknown.
-    /// Consumed by the fleet dashboard (#21).
-    #[allow(dead_code)]
     pub claude_activity: Option<String>,
     /// Unix timestamp (secs) when the current Claude state began. Used to show
     /// how long a pane has been working/waiting.
-    #[allow(dead_code)]
     pub claude_state_since: Option<i64>,
     /// Working directory Claude reported for this pane (repo identification).
     #[allow(dead_code)]
@@ -129,7 +126,6 @@ pub struct TmuxPane {
 
 impl TmuxPane {
     /// Seconds elapsed since the current Claude state began, if known.
-    #[allow(dead_code)]
     pub fn claude_state_elapsed_secs(&self) -> Option<i64> {
         self.claude_state_since
             .map(|since| crate::hook::now_secs().saturating_sub(since).max(0))
@@ -182,6 +178,22 @@ pub struct TmuxSession {
 pub enum ViewMode {
     TreeView,
     MultiPreview,
+    /// Full-screen fleet dashboard: every pane running Claude across all
+    /// sessions, sorted by how much it wants attention.
+    Dashboard,
+}
+
+/// One row of the fleet dashboard: a single pane running Claude, with the
+/// context needed to render it and to jump to it.
+#[derive(Debug, Clone)]
+pub struct DashboardRow {
+    /// tmux target (`session:window.pane`) for switching to this pane.
+    pub target: String,
+    pub session: String,
+    pub pane_id: String,
+    pub state: ClaudeState,
+    pub activity: Option<String>,
+    pub elapsed_secs: Option<i64>,
 }
 
 /// Focus area in TreeView mode
@@ -409,6 +421,9 @@ pub struct UIState {
     pub multi_session: usize,
     pub multi_window: usize,
 
+    /// Selected row index in the fleet dashboard (`ViewMode::Dashboard`).
+    pub dashboard_selected: usize,
+
     // Shared state
     pub pane_content: String,
     pub pane_content_parsed: Option<Text<'static>>,
@@ -469,6 +484,8 @@ impl UIState {
 
             multi_session: 0,
             multi_window: 0,
+
+            dashboard_selected: 0,
 
             pane_content: String::new(),
             pane_content_parsed: None,
@@ -548,7 +565,74 @@ impl UIState {
                 self.pane_list_state.select(Some(0));
                 ViewMode::TreeView
             }
+            // Double-space cycles only Tree <-> Multi; leaving the dashboard
+            // returns to the tree.
+            ViewMode::Dashboard => ViewMode::TreeView,
         };
+    }
+
+    // =========================================================================
+    // Fleet Dashboard
+    // =========================================================================
+
+    /// Toggle the fleet dashboard on/off. Entering it resets the selection.
+    pub fn toggle_dashboard(&mut self) {
+        if self.view_mode == ViewMode::Dashboard {
+            self.view_mode = ViewMode::TreeView;
+        } else {
+            self.dashboard_selected = 0;
+            self.view_mode = ViewMode::Dashboard;
+        }
+    }
+
+    /// All panes currently running Claude (or carrying a hook state), across
+    /// every session, sorted by attention priority (Waiting → Error → Working
+    /// → Done) and then by how long they have been in that state (longest
+    /// first), so a stuck/old item floats up within its group.
+    pub fn dashboard_rows(&self) -> Vec<DashboardRow> {
+        let mut rows: Vec<DashboardRow> = Vec::new();
+        for session in &self.sessions {
+            for window in &session.windows {
+                for pane in &window.panes {
+                    let Some(state) = pane.claude_state else {
+                        continue;
+                    };
+                    rows.push(DashboardRow {
+                        target: format!("{}:{}.{}", session.name, window.index, pane.index),
+                        session: session.name.clone(),
+                        pane_id: pane.id.clone(),
+                        state,
+                        activity: pane.claude_activity.clone(),
+                        elapsed_secs: pane.claude_state_elapsed_secs(),
+                    });
+                }
+            }
+        }
+        rows.sort_by(|a, b| {
+            b.state
+                .priority()
+                .cmp(&a.state.priority())
+                .then(b.elapsed_secs.cmp(&a.elapsed_secs))
+        });
+        rows
+    }
+
+    pub fn dashboard_move_up(&mut self) {
+        self.dashboard_selected = self.dashboard_selected.saturating_sub(1);
+    }
+
+    pub fn dashboard_move_down(&mut self) {
+        let len = self.dashboard_rows().len();
+        if len > 0 {
+            self.dashboard_selected = (self.dashboard_selected + 1).min(len - 1);
+        }
+    }
+
+    /// tmux target of the currently highlighted dashboard row, if any.
+    pub fn get_dashboard_target(&self) -> Option<String> {
+        self.dashboard_rows()
+            .get(self.dashboard_selected)
+            .map(|r| r.target.clone())
     }
 
     // =========================================================================
@@ -571,6 +655,7 @@ impl UIState {
         match self.view_mode {
             ViewMode::TreeView => self.get_selected_pane_target(),
             ViewMode::MultiPreview => self.get_multi_selected_target(),
+            ViewMode::Dashboard => self.get_dashboard_target(),
         }
     }
 
@@ -589,6 +674,7 @@ impl UIState {
                 Focus::Panes => self.get_selected_pane_target(),
             },
             ViewMode::MultiPreview => self.get_multi_selected_target(),
+            ViewMode::Dashboard => self.get_dashboard_target(),
         }
     }
 
@@ -1196,6 +1282,65 @@ mod tests {
         }
         state.update_sessions(names.iter().map(|n| session(n)).collect());
         state
+    }
+
+    /// Build a session with a single window holding the given panes, each
+    /// described as `(pane_id, index, claude_state, state_since)`.
+    fn session_with_panes(
+        name: &str,
+        panes: &[(&str, u32, Option<ClaudeState>, Option<i64>)],
+    ) -> TmuxSession {
+        let panes = panes
+            .iter()
+            .map(|(id, index, state, since)| TmuxPane {
+                id: id.to_string(),
+                index: *index,
+                width: 80,
+                height: 24,
+                active: false,
+                current_command: String::new(),
+                pid: 0,
+                has_claude: state.is_some(),
+                claude_state: *state,
+                claude_activity: None,
+                claude_state_since: *since,
+                claude_cwd: None,
+            })
+            .collect();
+        let mut s = session(name);
+        s.windows = vec![TmuxWindow {
+            index: 0,
+            name: "w".to_string(),
+            panes,
+            has_claude: false,
+            claude_state: None,
+        }];
+        s
+    }
+
+    #[test]
+    fn dashboard_rows_sort_by_attention_then_age() {
+        let mut state = UIState::new(Config::default());
+        state.groups = GroupStore::default();
+        // working(old) / working(new) / waiting / done — plus a non-Claude pane.
+        state.sessions = vec![session_with_panes(
+            "s",
+            &[
+                ("%1", 0, Some(ClaudeState::Working), Some(100)), // older working
+                ("%2", 1, Some(ClaudeState::Working), Some(200)), // newer working
+                ("%3", 2, Some(ClaudeState::Waiting), Some(150)),
+                ("%4", 3, Some(ClaudeState::Done), Some(10)),
+                ("%5", 4, None, None), // no Claude -> excluded
+            ],
+        )];
+
+        let rows = state.dashboard_rows();
+        // Waiting first; then the two Working (older = larger elapsed first);
+        // then Done. The non-Claude pane is excluded.
+        let order: Vec<&str> = rows.iter().map(|r| r.pane_id.as_str()).collect();
+        assert_eq!(order, vec!["%3", "%1", "%2", "%4"]);
+        assert_eq!(rows.len(), 4);
+        assert_eq!(rows[0].target, "s:0.2");
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -561,6 +561,8 @@ pub enum Action {
     NewSession,
     RenameSession,
     KillSession,
+    /// Toggle the fleet dashboard (all Claude panes, sorted by attention).
+    Dashboard,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -584,6 +586,8 @@ pub struct KeyBindings {
     pub rename_session: Vec<KeySpec>,
     #[serde(deserialize_with = "de_keys")]
     pub kill_session: Vec<KeySpec>,
+    #[serde(deserialize_with = "de_keys")]
+    pub dashboard: Vec<KeySpec>,
 }
 
 impl Default for KeyBindings {
@@ -599,6 +603,7 @@ impl Default for KeyBindings {
             new_session: vec![ctrl('n')],
             rename_session: vec![ctrl('r')],
             kill_session: vec![ctrl('x')],
+            dashboard: vec![key('d')],
         }
     }
 }
@@ -606,7 +611,7 @@ impl Default for KeyBindings {
 impl KeyBindings {
     /// Pairs of (action, bindings) in match priority order. Modifier-bearing
     /// bindings (e.g. `C-r`) are listed so they win over the plain `r` refresh.
-    fn entries(&self) -> [(Action, &Vec<KeySpec>); 9] {
+    fn entries(&self) -> [(Action, &Vec<KeySpec>); 10] {
         [
             (Action::NewSession, &self.new_session),
             (Action::RenameSession, &self.rename_session),
@@ -617,6 +622,7 @@ impl KeyBindings {
             (Action::Group, &self.group),
             (Action::Input, &self.input),
             (Action::Enter, &self.enter),
+            (Action::Dashboard, &self.dashboard),
         ]
     }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -4,8 +4,8 @@ use ratatui::{
 };
 
 use crate::app::{
-    ClaudeState, Focus, InputMode, PopupMode, SessionRow, TmuxPane, TmuxWindow, UIState,
-    UNGROUPED_LABEL, ViewMode,
+    ClaudeState, DashboardRow, Focus, InputMode, PopupMode, SessionRow, TmuxPane, TmuxWindow,
+    UIState, UNGROUPED_LABEL, ViewMode,
 };
 use crate::config::{Action, MarkerSet, Theme};
 
@@ -75,6 +75,7 @@ pub fn render_ui(frame: &mut Frame, state: &mut UIState) {
     match state.view_mode {
         ViewMode::TreeView => render_tree_view(frame, state),
         ViewMode::MultiPreview => render_multi_preview(frame, state),
+        ViewMode::Dashboard => render_dashboard(frame, state),
     }
 
     // Render input popup if in input mode
@@ -413,6 +414,8 @@ fn render_tree_status_bar(frame: &mut Frame, state: &UIState, area: Rect) {
             Span::raw(":fold "),
             Span::styled("Space×2", Style::default().fg(theme.highlight)),
             Span::raw(":multi "),
+            Span::styled(kb.label(Action::Dashboard), Style::default().fg(theme.focus_border)),
+            Span::raw(":fleet "),
             Span::styled(kb.label(Action::NewSession), Style::default().fg(theme.success)),
             Span::raw(":new "),
             Span::styled(kb.label(Action::RenameSession), Style::default().fg(theme.success)),
@@ -424,6 +427,120 @@ fn render_tree_status_bar(frame: &mut Frame, state: &UIState, area: Rect) {
         ])
     };
 
+    frame.render_widget(
+        Paragraph::new(status_text).style(Style::default().bg(theme.status_bar_bg)),
+        area,
+    );
+}
+
+// =============================================================================
+// Fleet Dashboard Rendering
+// =============================================================================
+
+/// Short uppercase label for a Claude state, used in the dashboard rows.
+fn claude_state_label(state: ClaudeState) -> &'static str {
+    match state {
+        ClaudeState::Waiting => "WAITING",
+        ClaudeState::Error => "ERROR",
+        ClaudeState::Working => "WORKING",
+        ClaudeState::Done => "DONE",
+    }
+}
+
+/// Human-friendly elapsed time: `12s`, `3m`, `2h`. `None` renders as `-`.
+fn format_elapsed(secs: Option<i64>) -> String {
+    match secs {
+        None => "-".to_string(),
+        Some(s) if s < 60 => format!("{s}s"),
+        Some(s) if s < 3600 => format!("{}m", s / 60),
+        Some(s) => format!("{}h", s / 3600),
+    }
+}
+
+/// Render the fleet dashboard: every pane running Claude, sorted by attention
+/// priority, with a one-line activity digest and how long it has been in its
+/// current state. Enter switches to the highlighted pane.
+fn render_dashboard(frame: &mut Frame, state: &UIState) {
+    let area = frame.area();
+    let theme = state.theme;
+
+    let chunks = Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).split(area);
+    let list_area = chunks[0];
+    let status_area = chunks[1];
+
+    let rows = state.dashboard_rows();
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(format!(" Claude Fleet ({}) ", rows.len()));
+
+    if rows.is_empty() {
+        let empty = Paragraph::new("No panes are running Claude.")
+            .style(Style::default().fg(theme.unfocus_border))
+            .block(block);
+        frame.render_widget(empty, list_area);
+    } else {
+        let selected = state.dashboard_selected.min(rows.len() - 1);
+        let items: Vec<ListItem> = rows
+            .iter()
+            .enumerate()
+            .map(|(idx, row)| dashboard_item(state, row, idx == selected))
+            .collect();
+        frame.render_widget(List::new(items).block(block), list_area);
+    }
+
+    render_dashboard_status_bar(frame, state, status_area);
+}
+
+/// Build a single dashboard row line.
+fn dashboard_item<'a>(state: &UIState, row: &DashboardRow, selected: bool) -> ListItem<'a> {
+    let theme = state.theme;
+    let (glyph, color) = claude_marker(&state.hooks.claude, Some(row.state), true)
+        .unwrap_or_else(|| ("•".to_string(), theme.unfocus_border));
+
+    let activity = row.activity.clone().unwrap_or_else(|| "—".to_string());
+    let line = Line::from(vec![
+        Span::styled(format!("{glyph} "), Style::default().fg(color)),
+        Span::styled(
+            format!("{:<7} ", claude_state_label(row.state)),
+            Style::default().fg(color).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            format!("{}:{:<6} ", row.session, row.pane_id),
+            Style::default().fg(theme.focus_border),
+        ),
+        Span::raw(format!("{activity:<40} ")),
+        Span::styled(
+            format!("{:>5}", format_elapsed(row.elapsed_secs)),
+            Style::default().fg(theme.unfocus_border),
+        ),
+    ]);
+
+    let style = if selected {
+        Style::default()
+            .bg(theme.selection_bg)
+            .fg(theme.selection_fg)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default()
+    };
+    ListItem::new(line).style(style)
+}
+
+fn render_dashboard_status_bar(frame: &mut Frame, state: &UIState, area: Rect) {
+    let theme = state.theme;
+    let kb = &state.keybindings;
+    let status_text = Line::from(vec![
+        Span::styled("j/k", Style::default().fg(theme.focus_border)),
+        Span::raw(":move "),
+        Span::styled(kb.label(Action::Enter), Style::default().fg(theme.highlight)),
+        Span::raw(":jump "),
+        Span::styled(kb.label(Action::Dashboard), Style::default().fg(theme.focus_border)),
+        Span::raw(":back "),
+        Span::styled(kb.label(Action::Refresh), Style::default().fg(theme.focus_border)),
+        Span::raw(":refresh "),
+        Span::styled(kb.label(Action::Quit), Style::default().fg(theme.focus_border)),
+        Span::raw(":quit"),
+    ]);
     frame.render_widget(
         Paragraph::new(status_text).style(Style::default().bg(theme.status_bar_bg)),
         area,
@@ -917,6 +1034,16 @@ mod cursor_alignment_tests {
     use super::*;
     use ratatui::{backend::TestBackend, Terminal};
 
+    #[test]
+    fn format_elapsed_scales_units() {
+        assert_eq!(format_elapsed(None), "-");
+        assert_eq!(format_elapsed(Some(0)), "0s");
+        assert_eq!(format_elapsed(Some(59)), "59s");
+        assert_eq!(format_elapsed(Some(60)), "1m");
+        assert_eq!(format_elapsed(Some(3599)), "59m");
+        assert_eq!(format_elapsed(Some(3600)), "1h");
+    }
+
     /// 白背景（カーソルブロック）のセルの (x, y) を返す。
     fn cursor_cell(buf: &ratatui::buffer::Buffer) -> Option<(u16, u16)> {
         for y in 0..buf.area.height {
@@ -956,5 +1083,14 @@ mod cursor_alignment_tests {
         let empty = render_name_popup_cursor("").expect("cursor visible when empty");
         let jp = render_name_popup_cursor("あい").expect("cursor visible with text");
         assert_eq!(empty.1, jp.1, "cursor row must not shift with multibyte input");
+    }
+
+    #[test]
+    fn dashboard_renders_without_panic() {
+        // Empty fleet: exercises the empty-state and status-bar paths.
+        let mut state = UIState::new(crate::config::Config::default());
+        state.view_mode = ViewMode::Dashboard;
+        let mut term = Terminal::new(TestBackend::new(80, 24)).unwrap();
+        term.draw(|f| render_ui(f, &mut state)).unwrap();
     }
 }


### PR DESCRIPTION
## 概要
フリート・ダッシュボード(#18)の **UI層 (#21)**。全セッション横断で Claude 稼働ペインを注意優先度順に一覧し、`Enter` で対象ペインへジャンプできる全画面ビューを追加。**これで #18 が完成**。

Closes #21 / Completes #18

> **Stacked PR**: base は #20 の `feature/claude-fleet-model`(PR #24)。スタック下流(#23 → #24)をマージ後、本PRの base は自動で繰り上がる。

## 操作
- `d` … ダッシュボードのトグル(設定可能。既定 `d`)
- `j/k` … 行移動
- `Enter` … 選択ペインへ `switch-client`
- ソート: Waiting → Error → Working → Done、同ティア内は経過時間が長い順

## 表示
```
◆ WAITING %3:    permission: Bash                         2m
⠹ WORKING %5:    Edit: src/app.rs                         12s
✓ DONE    %1:    —                                       just now
```
各行: 状態マーカー(既存 MarkerSet を再利用) / `session:pane` / 活動要約(#19/#20) / 経過時間。

## 変更点
- `app.rs`: `ViewMode::Dashboard` / `DashboardRow` / `dashboard_rows()`(抽出・ソート)/ ナビ・ターゲット取得 / `dashboard_selected`。#20 の一時 `#[allow(dead_code)]` を解除。
- `config.rs`: `Action::Dashboard`(既定 `d`)。
- `ui_actor.rs`: トグルアクションとダッシュボードのキー処理。
- `ui.rs`: `render_dashboard` + 専用ステータスバー。ツリーのステータスバーに `d:fleet` ヒント。
- Docs: README / config.example.toml にキーバインドと機能を記載。

## 設計メモ
- 既存のツリー内マーカー(本Epic以前から存在)が「簡易インライン表示」、本ダッシュボードが「詳細表示」で、#18 の決定 (c) を満たす。
- ダッシュボードは Tick ごとの `refresh_claude_states` でライブ更新。プレビュー capture は TreeView のみで従来どおり。

## テスト
- 追加: `dashboard_rows_sort_by_attention_then_age` / `format_elapsed_scales_units` / `dashboard_renders_without_panic`
- `cargo test` 47件パス / `cargo clippy` クリーン
🤖 Generated with [Claude Code](https://claude.com/claude-code)
