### PR TITLE
feat: agent view of Claude Code background sessions (claude agents)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Monitoring multi session Realtime preview.
 - 📄 Easy management Windows and Panes between Sessions
 - 👀 Realtime Preview
 - 🤖 Claude Code status markers (working / waiting / done) driven by hooks
-- 🛰️ Claude fleet dashboard (`d`): every Claude pane sorted by attention, jump with `Enter`
+- 🛰️ Claude fleet dashboard (`d`): a live grid mirroring every Claude agent's screen; `Tab` to focus, `Enter` to attach
 - ⚙️ Easy Configure
 
 # Quick Start

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Monitoring multi session Realtime preview.
 - 📄 Easy management Windows and Panes between Sessions
 - 👀 Realtime Preview
 - 🤖 Claude Code status markers (working / waiting / done) driven by hooks
-- 🛰️ Claude agent view (`d`): lists Claude Code background sessions (`claude agents`) grouped by directory — state, name, summary, PRs, elapsed — and `Enter` attaches via `claude attach`
+- 🛰️ Claude agent view (`d`): lists Claude Code background sessions (`claude agents`) grouped by directory — state, name, summary, PRs, elapsed. `Enter` attaches via `claude attach`, `p` toggles a transcript preview, `s` generates an execution summary (`claude -p`)
 - ⚙️ Easy Configure
 
 # Quick Start

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Monitoring multi session Realtime preview.
 - 📄 Easy management Windows and Panes between Sessions
 - 👀 Realtime Preview
 - 🤖 Claude Code status markers (working / waiting / done) driven by hooks
-- 🛰️ Claude fleet dashboard (`d`): agent-view-style list grouped by attention (Needs input / Working / Completed); `Space` to peek & reply, `Enter` to attach
+- 🛰️ Claude agent view (`d`): lists Claude Code background sessions (`claude agents`) grouped by directory — state, name, summary, PRs, elapsed — and `Enter` attaches via `claude attach`
 - ⚙️ Easy Configure
 
 # Quick Start

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Monitoring multi session Realtime preview.
 - 📄 Easy management Windows and Panes between Sessions
 - 👀 Realtime Preview
 - 🤖 Claude Code status markers (working / waiting / done) driven by hooks
-- 🛰️ Claude fleet dashboard (`d`): a live grid mirroring every Claude agent's screen; `Tab` to focus, `Enter` to attach
+- 🛰️ Claude fleet dashboard (`d`): agent-view-style list grouped by attention (Needs input / Working / Completed); `Space` to peek & reply, `Enter` to attach
 - ⚙️ Easy Configure
 
 # Quick Start

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -16,6 +16,13 @@
 interval = 50
 
 # -----------------------------------------------------------------------------
+[agents]
+# Model used by `claude -p` when generating an execution summary for the
+# selected background session in the agent view (press `s`). Accepts any
+# `claude --model` value: an alias (haiku / sonnet / opus) or a full model id.
+summary_model = "haiku"
+
+# -----------------------------------------------------------------------------
 [theme]
 # A named colour preset. One of:
 #   default       monochrome   dracula     nord        gruvbox

--- a/src/actor/ui_actor.rs
+++ b/src/actor/ui_actor.rs
@@ -135,7 +135,11 @@ impl UIActor {
                                     }
                                 }
                                 ViewMode::Dashboard => {
-                                    for (target, height) in self.state.claude_capture_targets() {
+                                    // Capture only the selected pane; its content
+                                    // feeds the peek panel.
+                                    if let Some((target, height)) =
+                                        self.state.dashboard_capture_target()
+                                    {
                                         let _ = self
                                             .tmux_capture_tx
                                             .send(TmuxCommand::CapturePane {
@@ -182,6 +186,11 @@ impl UIActor {
             // Handle popup mode first
             if let Some(popup_mode) = self.state.popup_mode {
                 return self.handle_popup_key(key, popup_mode).await;
+            }
+
+            // The dashboard peek panel captures keys while open (reply + nav).
+            if self.state.dashboard_peek {
+                return self.handle_dashboard_peek_key(key).await;
             }
 
             // Handle input mode
@@ -345,7 +354,13 @@ impl UIActor {
                     return Ok(false);
                 }
                 KeyCode::Char(' ') => {
-                    self.state.handle_space_press();
+                    // In the dashboard, Space opens the peek panel; elsewhere it
+                    // drives the double-Space view toggle.
+                    if self.state.view_mode == ViewMode::Dashboard {
+                        self.state.open_dashboard_peek();
+                    } else {
+                        self.state.handle_space_press();
+                    }
                     return Ok(false);
                 }
                 _ => {}
@@ -451,6 +466,63 @@ impl UIActor {
         Ok(())
     }
 
+    /// Keys while the dashboard peek panel is open: edit/send a reply, peek
+    /// adjacent rows, attach, or close.
+    async fn handle_dashboard_peek_key(&mut self, key: event::KeyEvent) -> Result<bool> {
+        match key.code {
+            KeyCode::Esc => self.state.close_dashboard_peek(),
+            // Up/Down peek the neighbouring session without leaving the panel.
+            KeyCode::Up => self.state.dashboard_focus_prev(),
+            KeyCode::Down => self.state.dashboard_focus_next(),
+            // Right attaches to the peeked session.
+            KeyCode::Right => {
+                if let Some(target) = self.state.get_dashboard_target() {
+                    self.state.close_dashboard_peek();
+                    let (reply_tx, reply_rx) = oneshot::channel();
+                    let _ = self
+                        .tmux_cmd_tx
+                        .send(TmuxCommand::SwitchClient {
+                            target,
+                            reply: Some(reply_tx),
+                        })
+                        .await;
+                    let _ = reply_rx.await;
+                    if self.state.behavior.exit_on_switch {
+                        return Ok(true);
+                    }
+                }
+            }
+            // Enter sends the typed reply to the peeked pane (text + Enter).
+            KeyCode::Enter => {
+                let keys = self.state.input_buffer.clone();
+                if !keys.is_empty()
+                    && let Some(target) = self.state.get_dashboard_target()
+                {
+                    let (reply_tx, reply_rx) = oneshot::channel();
+                    let _ = self
+                        .tmux_cmd_tx
+                        .send(TmuxCommand::SendKeys {
+                            target,
+                            keys,
+                            reply: Some(reply_tx),
+                        })
+                        .await;
+                    let _ = reply_rx.await;
+                    self.state.input_buffer.clear();
+                    self.state.input_cursor = 0;
+                }
+            }
+            KeyCode::Backspace => self.state.input_backspace(),
+            KeyCode::Delete => self.state.input_delete(),
+            KeyCode::Left => self.state.input_move_left(),
+            KeyCode::Home => self.state.input_move_home(),
+            KeyCode::End => self.state.input_move_end(),
+            KeyCode::Char(c) => self.state.input_char(c),
+            _ => {}
+        }
+        Ok(false)
+    }
+
     fn handle_navigation_key(&mut self, code: KeyCode) {
         match self.state.view_mode {
             ViewMode::TreeView => match code {
@@ -470,16 +542,12 @@ impl UIActor {
                 _ => {}
             },
             ViewMode::Dashboard => match code {
-                KeyCode::Tab
-                | KeyCode::Down
-                | KeyCode::Right
-                | KeyCode::Char('j')
-                | KeyCode::Char('l') => self.state.dashboard_focus_next(),
-                KeyCode::BackTab
-                | KeyCode::Up
-                | KeyCode::Left
-                | KeyCode::Char('k')
-                | KeyCode::Char('h') => self.state.dashboard_focus_prev(),
+                KeyCode::Down | KeyCode::Tab | KeyCode::Char('j') => {
+                    self.state.dashboard_focus_next()
+                }
+                KeyCode::Up | KeyCode::BackTab | KeyCode::Char('k') => {
+                    self.state.dashboard_focus_prev()
+                }
                 _ => {}
             },
         }

--- a/src/actor/ui_actor.rs
+++ b/src/actor/ui_actor.rs
@@ -2,7 +2,11 @@ use std::io;
 use std::time::Duration;
 
 use color_eyre::Result;
+use crossterm::ExecutableCommand;
 use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
+use crossterm::terminal::{
+    EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
+};
 use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
 use tokio::sync::{mpsc, oneshot};
@@ -120,10 +124,8 @@ impl UIActor {
                             // tmux refreshes.
                             self.state.refresh_claude_states();
 
-                            // Request pane capture (low-priority channel). TreeView
-                            // captures only the selected pane; the dashboard mirrors
-                            // every Claude pane so each tile shows live content.
                             match self.state.view_mode {
+                                // TreeView captures the selected pane for its preview.
                                 ViewMode::TreeView => {
                                     if let Some((target, start, end)) =
                                         self.state.get_selected_pane_target_with_capture_range()
@@ -134,22 +136,8 @@ impl UIActor {
                                             .await;
                                     }
                                 }
-                                ViewMode::Dashboard => {
-                                    // Capture only the selected pane; its content
-                                    // feeds the peek panel.
-                                    if let Some((target, height)) =
-                                        self.state.dashboard_capture_target()
-                                    {
-                                        let _ = self
-                                            .tmux_capture_tx
-                                            .send(TmuxCommand::CapturePane {
-                                                target,
-                                                start: 0,
-                                                end: height,
-                                            })
-                                            .await;
-                                    }
-                                }
+                                // The agent view reloads background sessions from disk.
+                                ViewMode::Dashboard => self.state.refresh_agents(),
                                 ViewMode::MultiPreview => {}
                             }
                         }
@@ -164,6 +152,13 @@ impl UIActor {
                 _ = anim.tick() => {
                     redraw = self.state.has_working_claude();
                 }
+            }
+
+            // An attach request suspends the TUI, hands the terminal to
+            // `claude attach <id>`, then restores the TUI when it returns.
+            if let Some(id) = self.state.pending_attach.take() {
+                self.attach_agent(&id)?;
+                continue;
             }
 
             // Render UI after processing event (event-driven rendering)
@@ -186,11 +181,6 @@ impl UIActor {
             // Handle popup mode first
             if let Some(popup_mode) = self.state.popup_mode {
                 return self.handle_popup_key(key, popup_mode).await;
-            }
-
-            // The dashboard peek panel captures keys while open (reply + nav).
-            if self.state.dashboard_peek {
-                return self.handle_dashboard_peek_key(key).await;
             }
 
             // Handle input mode
@@ -353,14 +343,8 @@ impl UIActor {
                     self.state.pending_z = true;
                     return Ok(false);
                 }
-                KeyCode::Char(' ') => {
-                    // In the dashboard, Space opens the peek panel; elsewhere it
-                    // drives the double-Space view toggle.
-                    if self.state.view_mode == ViewMode::Dashboard {
-                        self.state.open_dashboard_peek();
-                    } else {
-                        self.state.handle_space_press();
-                    }
+                KeyCode::Char(' ') if self.state.view_mode != ViewMode::Dashboard => {
+                    self.state.handle_space_press();
                     return Ok(false);
                 }
                 _ => {}
@@ -394,6 +378,11 @@ impl UIActor {
                 Action::KillSession => {
                     self.state.open_kill_session_popup();
                     self.refresh_control.pause();
+                }
+                Action::Enter if self.state.view_mode == ViewMode::Dashboard => {
+                    // Attach to the selected background session. The UI loop
+                    // consumes `pending_attach` to run `claude attach <id>`.
+                    self.state.pending_attach = self.state.selected_agent_id();
                 }
                 Action::Enter => {
                     if let Some(target) = self.state.get_enter_target() {
@@ -466,61 +455,31 @@ impl UIActor {
         Ok(())
     }
 
-    /// Keys while the dashboard peek panel is open: edit/send a reply, peek
-    /// adjacent rows, attach, or close.
-    async fn handle_dashboard_peek_key(&mut self, key: event::KeyEvent) -> Result<bool> {
-        match key.code {
-            KeyCode::Esc => self.state.close_dashboard_peek(),
-            // Up/Down peek the neighbouring session without leaving the panel.
-            KeyCode::Up => self.state.dashboard_focus_prev(),
-            KeyCode::Down => self.state.dashboard_focus_next(),
-            // Right attaches to the peeked session.
-            KeyCode::Right => {
-                if let Some(target) = self.state.get_dashboard_target() {
-                    self.state.close_dashboard_peek();
-                    let (reply_tx, reply_rx) = oneshot::channel();
-                    let _ = self
-                        .tmux_cmd_tx
-                        .send(TmuxCommand::SwitchClient {
-                            target,
-                            reply: Some(reply_tx),
-                        })
-                        .await;
-                    let _ = reply_rx.await;
-                    if self.state.behavior.exit_on_switch {
-                        return Ok(true);
-                    }
-                }
-            }
-            // Enter sends the typed reply to the peeked pane (text + Enter).
-            KeyCode::Enter => {
-                let keys = self.state.input_buffer.clone();
-                if !keys.is_empty()
-                    && let Some(target) = self.state.get_dashboard_target()
-                {
-                    let (reply_tx, reply_rx) = oneshot::channel();
-                    let _ = self
-                        .tmux_cmd_tx
-                        .send(TmuxCommand::SendKeys {
-                            target,
-                            keys,
-                            reply: Some(reply_tx),
-                        })
-                        .await;
-                    let _ = reply_rx.await;
-                    self.state.input_buffer.clear();
-                    self.state.input_cursor = 0;
-                }
-            }
-            KeyCode::Backspace => self.state.input_backspace(),
-            KeyCode::Delete => self.state.input_delete(),
-            KeyCode::Left => self.state.input_move_left(),
-            KeyCode::Home => self.state.input_move_home(),
-            KeyCode::End => self.state.input_move_end(),
-            KeyCode::Char(c) => self.state.input_char(c),
-            _ => {}
+    /// Suspend the TUI, run `claude attach <id>` with the terminal handed over,
+    /// then restore the TUI. Mirrors the agent view's attach/detach: when the
+    /// user detaches (or the session ends) we come back to the list.
+    fn attach_agent(&mut self, id: &str) -> Result<()> {
+        // Tear down our TUI so claude owns a clean terminal.
+        self.refresh_control.pause();
+        disable_raw_mode()?;
+        io::stdout().execute(LeaveAlternateScreen)?;
+
+        let status = std::process::Command::new("claude")
+            .arg("attach")
+            .arg(id)
+            .status();
+
+        // Restore the TUI regardless of how claude exited.
+        enable_raw_mode()?;
+        io::stdout().execute(EnterAlternateScreen)?;
+        self.terminal.clear()?;
+        self.refresh_control.resume();
+
+        if let Err(e) = status {
+            self.state.set_error(format!("claude attach failed: {e}"));
         }
-        Ok(false)
+        self.state.refresh_agents();
+        Ok(())
     }
 
     fn handle_navigation_key(&mut self, code: KeyCode) {
@@ -543,10 +502,10 @@ impl UIActor {
             },
             ViewMode::Dashboard => match code {
                 KeyCode::Down | KeyCode::Tab | KeyCode::Char('j') => {
-                    self.state.dashboard_focus_next()
+                    self.state.agent_select_next()
                 }
                 KeyCode::Up | KeyCode::BackTab | KeyCode::Char('k') => {
-                    self.state.dashboard_focus_prev()
+                    self.state.agent_select_prev()
                 }
                 _ => {}
             },
@@ -558,14 +517,8 @@ impl UIActor {
             TmuxResponse::SessionsRefreshed { sessions } => {
                 self.state.update_sessions(sessions);
             }
-            TmuxResponse::PaneCaptured { target, content } => {
-                // In the dashboard, captures fan out to per-pane tiles; elsewhere
-                // they feed the single TreeView preview.
-                if self.state.view_mode == ViewMode::Dashboard {
-                    self.state.update_dashboard_capture(target, content);
-                } else {
-                    self.state.update_pane_content(content);
-                }
+            TmuxResponse::PaneCaptured { target: _, content } => {
+                self.state.update_pane_content(content);
             }
             TmuxResponse::SessionCreated {
                 name,

--- a/src/actor/ui_actor.rs
+++ b/src/actor/ui_actor.rs
@@ -120,15 +120,33 @@ impl UIActor {
                             // tmux refreshes.
                             self.state.refresh_claude_states();
 
-                            // Request pane capture if in TreeView mode (low-priority channel)
-                            if self.state.view_mode == ViewMode::TreeView
-                                && let Some((target, start, end)) =
-                                    self.state.get_selected_pane_target_with_capture_range()
-                            {
-                                let _ = self
-                                    .tmux_capture_tx
-                                    .send(TmuxCommand::CapturePane { target, start, end })
-                                    .await;
+                            // Request pane capture (low-priority channel). TreeView
+                            // captures only the selected pane; the dashboard mirrors
+                            // every Claude pane so each tile shows live content.
+                            match self.state.view_mode {
+                                ViewMode::TreeView => {
+                                    if let Some((target, start, end)) =
+                                        self.state.get_selected_pane_target_with_capture_range()
+                                    {
+                                        let _ = self
+                                            .tmux_capture_tx
+                                            .send(TmuxCommand::CapturePane { target, start, end })
+                                            .await;
+                                    }
+                                }
+                                ViewMode::Dashboard => {
+                                    for (target, height) in self.state.claude_capture_targets() {
+                                        let _ = self
+                                            .tmux_capture_tx
+                                            .send(TmuxCommand::CapturePane {
+                                                target,
+                                                start: 0,
+                                                end: height,
+                                            })
+                                            .await;
+                                    }
+                                }
+                                ViewMode::MultiPreview => {}
                             }
                         }
                         UIEvent::Shutdown => {
@@ -452,8 +470,16 @@ impl UIActor {
                 _ => {}
             },
             ViewMode::Dashboard => match code {
-                KeyCode::Up | KeyCode::Char('k') => self.state.dashboard_move_up(),
-                KeyCode::Down | KeyCode::Char('j') => self.state.dashboard_move_down(),
+                KeyCode::Tab
+                | KeyCode::Down
+                | KeyCode::Right
+                | KeyCode::Char('j')
+                | KeyCode::Char('l') => self.state.dashboard_focus_next(),
+                KeyCode::BackTab
+                | KeyCode::Up
+                | KeyCode::Left
+                | KeyCode::Char('k')
+                | KeyCode::Char('h') => self.state.dashboard_focus_prev(),
                 _ => {}
             },
         }
@@ -464,8 +490,14 @@ impl UIActor {
             TmuxResponse::SessionsRefreshed { sessions } => {
                 self.state.update_sessions(sessions);
             }
-            TmuxResponse::PaneCaptured { target: _, content } => {
-                self.state.update_pane_content(content);
+            TmuxResponse::PaneCaptured { target, content } => {
+                // In the dashboard, captures fan out to per-pane tiles; elsewhere
+                // they feed the single TreeView preview.
+                if self.state.view_mode == ViewMode::Dashboard {
+                    self.state.update_dashboard_capture(target, content);
+                } else {
+                    self.state.update_pane_content(content);
+                }
             }
             TmuxResponse::SessionCreated {
                 name,

--- a/src/actor/ui_actor.rs
+++ b/src/actor/ui_actor.rs
@@ -366,7 +366,16 @@ impl UIActor {
                     return Ok(false);
                 }
                 KeyCode::Char('s') if self.state.view_mode == ViewMode::Dashboard => {
+                    self.state.open_agent_summary();
                     self.request_agent_summary();
+                    return Ok(false);
+                }
+                // Esc closes the summary popup before falling through to quit.
+                KeyCode::Esc
+                    if self.state.view_mode == ViewMode::Dashboard
+                        && self.state.agent_summary_open =>
+                {
+                    self.state.close_agent_summary();
                     return Ok(false);
                 }
                 _ => {}

--- a/src/actor/ui_actor.rs
+++ b/src/actor/ui_actor.rs
@@ -52,6 +52,9 @@ pub struct UIActor {
     ui_event_rx: mpsc::Receiver<UIEvent>,
     key_rx: mpsc::Receiver<Event>,
     refresh_control: RefreshControl,
+    /// Results of background `claude -p` summary jobs: (session id, Ok(text)/Err).
+    agent_summary_tx: mpsc::Sender<(String, Result<String, String>)>,
+    agent_summary_rx: mpsc::Receiver<(String, Result<String, String>)>,
 }
 
 impl UIActor {
@@ -68,6 +71,8 @@ impl UIActor {
         let (key_tx, key_rx) = mpsc::channel::<Event>(64);
         spawn_key_event_poller(key_tx);
 
+        let (agent_summary_tx, agent_summary_rx) = mpsc::channel(8);
+
         Self {
             terminal,
             state,
@@ -77,6 +82,8 @@ impl UIActor {
             ui_event_rx,
             key_rx,
             refresh_control,
+            agent_summary_tx,
+            agent_summary_rx,
         }
     }
 
@@ -108,6 +115,11 @@ impl UIActor {
                     if self.handle_key_event(event).await? {
                         break; // Exit requested
                     }
+                }
+
+                // Completed background summary jobs.
+                Some((id, result)) = self.agent_summary_rx.recv() => {
+                    self.state.set_summary_result(id, result);
                 }
 
                 // TmuxActor responses
@@ -347,6 +359,16 @@ impl UIActor {
                     self.state.handle_space_press();
                     return Ok(false);
                 }
+                // Agent-view-only keys: `p` toggles the preview panel, `s`
+                // generates an execution summary for the selected session.
+                KeyCode::Char('p') if self.state.view_mode == ViewMode::Dashboard => {
+                    self.state.toggle_agent_preview();
+                    return Ok(false);
+                }
+                KeyCode::Char('s') if self.state.view_mode == ViewMode::Dashboard => {
+                    self.request_agent_summary();
+                    return Ok(false);
+                }
                 _ => {}
             }
         }
@@ -482,6 +504,38 @@ impl UIActor {
         Ok(())
     }
 
+    /// Kick off an execution summary for the selected background session by
+    /// running `claude -p` (stateless, against a transcript digest) in a
+    /// background task. The result is delivered over `agent_summary_rx`.
+    fn request_agent_summary(&mut self) {
+        let Some(session) = self.state.selected_agent() else {
+            return;
+        };
+        // Don't double-dispatch while one is already running.
+        if matches!(
+            self.state.summary_status(&session.id),
+            Some(crate::app::SummaryStatus::Pending)
+        ) {
+            return;
+        }
+        let Some(path) = session.transcript_path.clone() else {
+            self.state.set_summary_result(
+                session.id.clone(),
+                Err("no transcript for this session".into()),
+            );
+            return;
+        };
+        let id = session.id.clone();
+        let model = self.state.agents_config.summary_model.clone();
+        let tx = self.agent_summary_tx.clone();
+        self.state.set_summary_pending(id.clone());
+
+        tokio::spawn(async move {
+            let result = generate_summary(&path, &model).await;
+            let _ = tx.send((id, result)).await;
+        });
+    }
+
     fn handle_navigation_key(&mut self, code: KeyCode) {
         match self.state.view_mode {
             ViewMode::TreeView => match code {
@@ -580,6 +634,42 @@ impl UIActor {
                 self.state.set_error(message);
             }
         }
+    }
+}
+
+/// Run `claude -p` against a transcript digest to summarise what a background
+/// session did. Stateless (no `--resume`), so it never touches the live
+/// session or its transcript. Returns the summary text or an error message.
+async fn generate_summary(transcript_path: &str, model: &str) -> Result<String, String> {
+    let digest = crate::agents::transcript_digest(transcript_path, 6000);
+    if digest.trim().is_empty() {
+        return Err("transcript is empty".into());
+    }
+    let prompt = format!(
+        "以下は Claude Code セッションの会話抜粋です。このセッションがこれまでに\
+         何をしたかを、日本語で3〜5個の簡潔な箇条書きに要約してください。前置きや\
+         結びの文は不要です。\n\n---\n{digest}"
+    );
+
+    let output = tokio::process::Command::new("claude")
+        .arg("-p")
+        .arg(&prompt)
+        .arg("--model")
+        .arg(model)
+        .output()
+        .await
+        .map_err(|e| format!("failed to run claude: {e}"))?;
+
+    if !output.status.success() {
+        let err = String::from_utf8_lossy(&output.stderr);
+        let msg = err.lines().next().unwrap_or("claude exited with error");
+        return Err(msg.to_string());
+    }
+    let text = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if text.is_empty() {
+        Err("empty summary".into())
+    } else {
+        Ok(text)
     }
 }
 

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -1,0 +1,320 @@
+//! Claude Code background-session ("agents view") integration.
+//!
+//! Claude Code hosts background sessions through a per-user supervisor and
+//! persists each one's state under `$CLAUDE_CONFIG_DIR/jobs/<id>/state.json`
+//! (default `~/.claude/jobs`). This module reads those files — the same source
+//! `claude agents` renders — so tmux-deck can show and manage the very sessions
+//! that appear in the agent view, grouped by working directory.
+//!
+//! This is independent of the tmux/hook integration in [`crate::hook`]: those
+//! track interactive Claude running in tmux panes; the sessions here are
+//! supervisor-hosted background sessions that need no terminal attached.
+
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde_json::Value;
+
+/// Lifecycle state of a background session, mirroring the agent view.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentState {
+    /// Waiting on the user (a question or permission decision).
+    Blocked,
+    /// Actively generating or running tools.
+    Working,
+    /// Nothing to do, ready for the next prompt.
+    Idle,
+    /// Task finished successfully.
+    Done,
+    /// Ended with an error.
+    Failed,
+    /// Stopped by the user.
+    Stopped,
+    /// Anything not recognised.
+    Unknown,
+}
+
+impl AgentState {
+    fn parse(s: &str) -> Self {
+        match s {
+            "blocked" => Self::Blocked,
+            "working" => Self::Working,
+            "idle" => Self::Idle,
+            "done" | "completed" => Self::Done,
+            "failed" | "error" => Self::Failed,
+            "stopped" => Self::Stopped,
+            _ => Self::Unknown,
+        }
+    }
+
+    /// Attention group the session is shown under, like the agent view's
+    /// "Needs input / Working / Completed" sections.
+    pub fn group(self) -> AgentGroup {
+        match self {
+            Self::Blocked => AgentGroup::NeedsInput,
+            Self::Working | Self::Idle | Self::Unknown => AgentGroup::Working,
+            Self::Done | Self::Failed | Self::Stopped => AgentGroup::Completed,
+        }
+    }
+
+}
+
+/// Attention grouping for the list (highest attention first).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentGroup {
+    NeedsInput,
+    Working,
+    Completed,
+}
+
+/// A pull request the session opened.
+#[derive(Debug, Clone)]
+pub struct PrRef {
+    pub id: String,
+}
+
+/// One background session as shown in the agent view.
+#[derive(Debug, Clone)]
+pub struct AgentSession {
+    /// Short id (the `jobs/<id>` directory name) used by `claude attach <id>`.
+    pub id: String,
+    pub name: String,
+    pub state: AgentState,
+    /// One-line summary: the pending question when blocked, else the latest detail.
+    pub summary: String,
+    /// Working directory the session runs in (used to group the list).
+    pub cwd: String,
+    /// Seconds since the session state last changed (state.json mtime).
+    pub elapsed_secs: i64,
+    pub prs: Vec<PrRef>,
+    /// True while the supervisor has a live worker process for this session.
+    pub alive: bool,
+}
+
+fn now_secs() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+/// Root Claude config dir, honouring `CLAUDE_CONFIG_DIR` like Claude Code does.
+fn claude_config_dir() -> Option<PathBuf> {
+    if let Some(dir) = std::env::var_os("CLAUDE_CONFIG_DIR") {
+        return Some(PathBuf::from(dir));
+    }
+    std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".claude"))
+}
+
+/// Ids of sessions the supervisor currently has a live worker for.
+fn alive_ids(config_dir: &std::path::Path) -> std::collections::HashSet<String> {
+    let path = config_dir.join("daemon").join("roster.json");
+    let mut set = std::collections::HashSet::new();
+    if let Ok(content) = std::fs::read_to_string(&path)
+        && let Ok(v) = serde_json::from_str::<Value>(&content)
+        && let Some(workers) = v.get("workers").and_then(|w| w.as_object())
+    {
+        for id in workers.keys() {
+            set.insert(id.clone());
+        }
+    }
+    set
+}
+
+fn one_line(s: &str, max: usize) -> String {
+    let collapsed = s.split_whitespace().collect::<Vec<_>>().join(" ");
+    if collapsed.chars().count() > max {
+        let head: String = collapsed.chars().take(max - 1).collect();
+        format!("{head}…")
+    } else {
+        collapsed
+    }
+}
+
+/// Load all background sessions from `~/.claude/jobs/*/state.json`, sorted for
+/// display: grouped by working directory (the directory with the most-pressing
+/// / most-recent session first), and within a directory by attention group
+/// then recency. Returns an empty list when no sessions exist or the directory
+/// is unreadable — never errors, so it can't break the TUI.
+pub fn load_agent_sessions() -> Vec<AgentSession> {
+    let Some(config_dir) = claude_config_dir() else {
+        return Vec::new();
+    };
+    let jobs_dir = config_dir.join("jobs");
+    let alive = alive_ids(&config_dir);
+    let now = now_secs();
+
+    let mut sessions = Vec::new();
+    let Ok(entries) = std::fs::read_dir(&jobs_dir) else {
+        return Vec::new();
+    };
+    for entry in entries.flatten() {
+        let id = entry.file_name().to_string_lossy().to_string();
+        let state_path = entry.path().join("state.json");
+        let Ok(content) = std::fs::read_to_string(&state_path) else {
+            continue;
+        };
+        let Ok(v) = serde_json::from_str::<Value>(&content) else {
+            continue;
+        };
+
+        let state = AgentState::parse(v.get("state").and_then(|s| s.as_str()).unwrap_or(""));
+        let name = v
+            .get("name")
+            .and_then(|s| s.as_str())
+            .filter(|s| !s.is_empty())
+            .unwrap_or(&id)
+            .to_string();
+        // Prefer the pending question, fall back to the latest detail.
+        let summary_raw = v
+            .get("needs")
+            .and_then(|s| s.as_str())
+            .filter(|s| !s.is_empty())
+            .or_else(|| v.get("detail").and_then(|s| s.as_str()))
+            .unwrap_or("");
+        let cwd = v
+            .get("cwd")
+            .and_then(|s| s.as_str())
+            .unwrap_or("")
+            .to_string();
+        let prs = v
+            .get("children")
+            .and_then(|c| c.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter(|c| c.get("kind").and_then(|k| k.as_str()) == Some("pr"))
+                    .filter_map(|c| c.get("id").and_then(|i| i.as_str()))
+                    .map(|id| PrRef { id: id.to_string() })
+                    .collect()
+            })
+            .unwrap_or_default();
+        // Use the state file's mtime as "last changed", avoiding date parsing.
+        let elapsed_secs = std::fs::metadata(&state_path)
+            .and_then(|m| m.modified())
+            .ok()
+            .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+            .map(|d| (now - d.as_secs() as i64).max(0))
+            .unwrap_or(0);
+
+        sessions.push(AgentSession {
+            alive: alive.contains(&id),
+            id,
+            name,
+            state,
+            summary: one_line(summary_raw, 80),
+            cwd,
+            elapsed_secs,
+            prs,
+        });
+    }
+
+    sort_for_display(&mut sessions);
+    sessions
+}
+
+/// Attention rank within a directory: needy first, then recency.
+fn attention_key(s: &AgentSession) -> (u8, i64) {
+    let group = match s.state.group() {
+        AgentGroup::NeedsInput => 0,
+        AgentGroup::Working => 1,
+        AgentGroup::Completed => 2,
+    };
+    (group, s.elapsed_secs)
+}
+
+/// Sort sessions so they render grouped by directory. Directories are ordered
+/// by their most-pressing session; within a directory, by attention then
+/// recency. This keeps the flat `Vec` order identical to the rendered order so
+/// a selection index maps directly onto it.
+fn sort_for_display(sessions: &mut [AgentSession]) {
+    use std::collections::HashMap;
+    // Rank each directory by its best (smallest) attention key.
+    let mut dir_rank: HashMap<String, (u8, i64)> = HashMap::new();
+    for s in sessions.iter() {
+        let key = attention_key(s);
+        dir_rank
+            .entry(s.cwd.clone())
+            .and_modify(|best| {
+                if key < *best {
+                    *best = key;
+                }
+            })
+            .or_insert(key);
+    }
+    sessions.sort_by(|a, b| {
+        let ra = dir_rank.get(&a.cwd).copied().unwrap_or((u8::MAX, i64::MAX));
+        let rb = dir_rank.get(&b.cwd).copied().unwrap_or((u8::MAX, i64::MAX));
+        ra.cmp(&rb)
+            .then_with(|| a.cwd.cmp(&b.cwd))
+            .then_with(|| attention_key(a).cmp(&attention_key(b)))
+    });
+}
+
+/// Abbreviate a path for a group header, replacing `$HOME` with `~`.
+pub fn abbreviate_path(path: &str) -> String {
+    if let Some(home) = std::env::var_os("HOME") {
+        let home = home.to_string_lossy();
+        if let Some(rest) = path.strip_prefix(home.as_ref()) {
+            return format!("~{rest}");
+        }
+    }
+    path.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sess(cwd: &str, state: AgentState, elapsed: i64) -> AgentSession {
+        AgentSession {
+            id: format!("{cwd}-{elapsed}"),
+            name: "n".into(),
+            state,
+            summary: String::new(),
+            cwd: cwd.into(),
+            elapsed_secs: elapsed,
+            prs: Vec::new(),
+            alive: true,
+        }
+    }
+
+    #[test]
+    fn state_parse_and_grouping() {
+        assert_eq!(AgentState::parse("blocked"), AgentState::Blocked);
+        assert_eq!(AgentState::parse("done").group(), AgentGroup::Completed);
+        assert_eq!(AgentState::parse("working").group(), AgentGroup::Working);
+        assert_eq!(AgentState::parse("???"), AgentState::Unknown);
+    }
+
+    #[test]
+    fn sort_groups_by_directory_with_needy_dir_first() {
+        // dir "b" has a blocked session (needs input) so it should come before
+        // dir "a" whose sessions are only working/done. Within a dir, the
+        // needier/most-recent session leads.
+        let mut v = vec![
+            sess("a", AgentState::Done, 10),
+            sess("b", AgentState::Working, 5),
+            sess("a", AgentState::Working, 20),
+            sess("b", AgentState::Blocked, 99),
+        ];
+        sort_for_display(&mut v);
+        let order: Vec<(&str, AgentState)> = v.iter().map(|s| (s.cwd.as_str(), s.state)).collect();
+        assert_eq!(
+            order,
+            vec![
+                ("b", AgentState::Blocked),
+                ("b", AgentState::Working),
+                ("a", AgentState::Working),
+                ("a", AgentState::Done),
+            ]
+        );
+    }
+
+    #[test]
+    fn abbreviate_path_replaces_home() {
+        // SAFETY: single-threaded test process.
+        unsafe { std::env::set_var("HOME", "/home/u") };
+        assert_eq!(abbreviate_path("/home/u/proj"), "~/proj");
+        assert_eq!(abbreviate_path("/etc/x"), "/etc/x");
+    }
+}

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -89,6 +89,8 @@ pub struct AgentSession {
     pub prs: Vec<PrRef>,
     /// True while the supervisor has a live worker process for this session.
     pub alive: bool,
+    /// Path to the conversation transcript JSONL, if known (for preview/summary).
+    pub transcript_path: Option<String>,
 }
 
 fn now_secs() -> i64 {
@@ -196,6 +198,11 @@ pub fn load_agent_sessions() -> Vec<AgentSession> {
             .map(|d| (now - d.as_secs() as i64).max(0))
             .unwrap_or(0);
 
+        let transcript_path = v
+            .get("linkScanPath")
+            .and_then(|s| s.as_str())
+            .map(String::from);
+
         sessions.push(AgentSession {
             alive: alive.contains(&id),
             id,
@@ -205,6 +212,7 @@ pub fn load_agent_sessions() -> Vec<AgentSession> {
             cwd,
             elapsed_secs,
             prs,
+            transcript_path,
         });
     }
 
@@ -250,6 +258,89 @@ fn sort_for_display(sessions: &mut [AgentSession]) {
     });
 }
 
+/// Extract human-readable lines from one transcript JSONL record. Returns
+/// labelled lines for user prompts, assistant text and tool calls; `thinking`
+/// blocks, snapshots and other internal records yield nothing.
+fn transcript_record_lines(v: &Value) -> Vec<String> {
+    let ty = v.get("type").and_then(|t| t.as_str()).unwrap_or("");
+    if ty != "user" && ty != "assistant" {
+        return Vec::new();
+    }
+    let role = v
+        .get("message")
+        .and_then(|m| m.get("role"))
+        .and_then(|r| r.as_str())
+        .unwrap_or(ty);
+    let content = match v.get("message").and_then(|m| m.get("content")) {
+        Some(c) => c,
+        None => return Vec::new(),
+    };
+
+    let mut out = Vec::new();
+    let mut push = |prefix: &str, text: String| {
+        let t = one_line(&text, 200);
+        if !t.is_empty() {
+            out.push(format!("{prefix} {t}"));
+        }
+    };
+
+    match content {
+        // User prompts are often a bare string.
+        Value::String(s) => push("▸", s.clone()),
+        Value::Array(blocks) => {
+            for b in blocks {
+                match b.get("type").and_then(|t| t.as_str()) {
+                    Some("text") => {
+                        if let Some(t) = b.get("text").and_then(|t| t.as_str()) {
+                            let prefix = if role == "user" { "▸" } else { "●" };
+                            push(prefix, t.to_string());
+                        }
+                    }
+                    Some("tool_use") => {
+                        let name = b.get("name").and_then(|n| n.as_str()).unwrap_or("tool");
+                        push("⏺", name.to_string());
+                    }
+                    // Skip thinking, tool_result, images, etc.
+                    _ => {}
+                }
+            }
+        }
+        _ => {}
+    }
+    out
+}
+
+/// Read the tail of a transcript as readable lines (latest last), for the
+/// preview panel. Reads the whole file (transcripts are local and modest);
+/// returns at most `max_lines` formatted lines.
+pub fn transcript_tail(path: &str, max_lines: usize) -> Vec<String> {
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return vec!["(transcript unavailable)".to_string()];
+    };
+    let mut lines: Vec<String> = Vec::new();
+    for raw in content.lines() {
+        if let Ok(v) = serde_json::from_str::<Value>(raw) {
+            lines.extend(transcript_record_lines(&v));
+        }
+    }
+    if lines.len() > max_lines {
+        lines = lines.split_off(lines.len() - max_lines);
+    }
+    lines
+}
+
+/// Build a compact text digest of a transcript for the summary prompt, capped
+/// at roughly `max_chars` characters (keeping the most recent content).
+pub fn transcript_digest(path: &str, max_chars: usize) -> String {
+    let mut lines = transcript_tail(path, 400);
+    let mut digest = lines.join("\n");
+    while digest.chars().count() > max_chars && !lines.is_empty() {
+        lines.remove(0);
+        digest = lines.join("\n");
+    }
+    digest
+}
+
 /// Abbreviate a path for a group header, replacing `$HOME` with `~`.
 pub fn abbreviate_path(path: &str) -> String {
     if let Some(home) = std::env::var_os("HOME") {
@@ -275,6 +366,7 @@ mod tests {
             elapsed_secs: elapsed,
             prs: Vec::new(),
             alive: true,
+            transcript_path: None,
         }
     }
 

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -277,10 +277,14 @@ fn transcript_record_lines(v: &Value) -> Vec<String> {
     };
 
     let mut out = Vec::new();
+    // Two spaces after the marker: the geometric/emoji glyphs are East Asian
+    // *Ambiguous* width, so some terminals render them 2 cells wide while
+    // unicode-width counts 1. The extra space keeps text from overlapping the
+    // icon in those terminals.
     let mut push = |prefix: &str, text: String| {
         let t = one_line(&text, 200);
         if !t.is_empty() {
-            out.push(format!("{prefix} {t}"));
+            out.push(format!("{prefix}  {t}"));
         }
     };
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -183,6 +183,46 @@ pub enum ViewMode {
     Dashboard,
 }
 
+/// Attention groups for the fleet list, mirroring Claude Code's agent view.
+/// Sessions needing the user float to the top.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DashboardGroup {
+    NeedsInput,
+    Working,
+    Completed,
+}
+
+impl DashboardGroup {
+    /// Which group a pane state belongs to. `None` (running, no hook state yet)
+    /// is treated as Working; `Error` is collected under Completed like the
+    /// agent view does.
+    pub fn of(state: Option<ClaudeState>) -> Self {
+        match state {
+            Some(ClaudeState::Waiting) => Self::NeedsInput,
+            Some(ClaudeState::Working) | None => Self::Working,
+            Some(ClaudeState::Done) | Some(ClaudeState::Error) => Self::Completed,
+        }
+    }
+
+    /// Display order (smaller = higher up): attention first.
+    fn order(self) -> u8 {
+        match self {
+            Self::NeedsInput => 0,
+            Self::Working => 1,
+            Self::Completed => 2,
+        }
+    }
+
+    /// Header label shown above the group.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::NeedsInput => "Needs input",
+            Self::Working => "Working",
+            Self::Completed => "Completed",
+        }
+    }
+}
+
 /// One row of the fleet dashboard: a single pane running Claude, with the
 /// context needed to render it and to jump to it.
 #[derive(Debug, Clone)]
@@ -196,6 +236,14 @@ pub struct DashboardRow {
     pub state: Option<ClaudeState>,
     pub activity: Option<String>,
     pub elapsed_secs: Option<i64>,
+    /// Visible pane height, used to size the peek capture.
+    pub height: u32,
+}
+
+impl DashboardRow {
+    pub fn group(&self) -> DashboardGroup {
+        DashboardGroup::of(self.state)
+    }
 }
 
 /// Focus area in TreeView mode
@@ -425,10 +473,11 @@ pub struct UIState {
 
     /// Focused tile index in the fleet dashboard grid (`ViewMode::Dashboard`).
     pub dashboard_selected: usize,
-    /// Live captured screen content per Claude pane, keyed by tmux target
-    /// (`session:window.pane`). Refreshed while the dashboard is open so each
-    /// tile mirrors the agent's real TUI.
+    /// Captured screen content keyed by tmux target (`session:window.pane`),
+    /// used to populate the peek panel for the selected pane.
     pub dashboard_captures: HashMap<String, Text<'static>>,
+    /// Whether the peek panel (latest output + reply) is open.
+    pub dashboard_peek: bool,
 
     // Shared state
     pub pane_content: String,
@@ -493,6 +542,7 @@ impl UIState {
 
             dashboard_selected: 0,
             dashboard_captures: HashMap::new(),
+            dashboard_peek: false,
 
             pane_content: String::new(),
             pane_content_parsed: None,
@@ -582,10 +632,11 @@ impl UIState {
     // Fleet Dashboard
     // =========================================================================
 
-    /// Toggle the fleet dashboard on/off. Entering it resets the focus and
-    /// drops any stale captures so tiles repopulate from scratch.
+    /// Toggle the fleet dashboard on/off. Entering it resets the selection and
+    /// drops stale captures; leaving it also closes any open peek panel.
     pub fn toggle_dashboard(&mut self) {
         if self.view_mode == ViewMode::Dashboard {
+            self.close_dashboard_peek();
             self.view_mode = ViewMode::TreeView;
         } else {
             self.dashboard_selected = 0;
@@ -594,32 +645,14 @@ impl UIState {
         }
     }
 
-    /// tmux targets + visible height of every Claude pane, used to schedule the
-    /// periodic capture that feeds the dashboard tiles.
-    pub fn claude_capture_targets(&self) -> Vec<(String, i32)> {
-        let mut out = Vec::new();
-        for session in &self.sessions {
-            for window in &session.windows {
-                for pane in &window.panes {
-                    if pane.claude_state.is_some() || pane.has_claude {
-                        let target = format!("{}:{}.{}", session.name, window.index, pane.index);
-                        let height = i32::try_from(pane.height).unwrap_or(i32::MAX);
-                        out.push((target, height));
-                    }
-                }
-            }
-        }
-        out
-    }
-
-    /// Store a freshly captured pane screen for the dashboard, parsing ANSI.
+    /// Store a freshly captured pane screen for the peek panel, parsing ANSI.
     pub fn update_dashboard_capture(&mut self, target: String, content: String) {
         if let Ok(text) = content.as_bytes().into_text() {
             self.dashboard_captures.insert(target, text);
         }
     }
 
-    /// Captured screen for a dashboard tile, if one has arrived yet.
+    /// Captured screen for a pane, if one has arrived yet.
     pub fn dashboard_capture(&self, target: &str) -> Option<&Text<'static>> {
         self.dashboard_captures.get(target)
     }
@@ -627,9 +660,9 @@ impl UIState {
     /// All panes running Claude across every session: any pane with a hook
     /// state, plus panes where a Claude process is detected even if no hook
     /// event has arrived yet (or hooks are not installed) — those show with a
-    /// `None` state. Sorted by attention priority (Waiting → Error → Working →
-    /// Done → unknown) and then by how long they have been in that state
-    /// (longest first), so a stuck/old item floats up within its group.
+    /// `None` state. Ordered by attention group (Needs input → Working →
+    /// Completed) and, within a group, longest-in-state first so a stuck/old
+    /// item floats up.
     pub fn dashboard_rows(&self) -> Vec<DashboardRow> {
         let mut rows: Vec<DashboardRow> = Vec::new();
         for session in &self.sessions {
@@ -645,22 +678,22 @@ impl UIState {
                         state: pane.claude_state,
                         activity: pane.claude_activity.clone(),
                         elapsed_secs: pane.claude_state_elapsed_secs(),
+                        height: pane.height,
                     });
                 }
             }
         }
-        // A known state outranks an unknown (running-only) one; within a tier,
-        // the longer-running item comes first.
-        let rank = |s: Option<ClaudeState>| s.map(|s| i16::from(s.priority())).unwrap_or(-1);
         rows.sort_by(|a, b| {
-            rank(b.state)
-                .cmp(&rank(a.state))
+            a.group()
+                .order()
+                .cmp(&b.group().order())
                 .then(b.elapsed_secs.cmp(&a.elapsed_secs))
         });
         rows
     }
 
-    /// Move tile focus to the previous Claude pane (wraps around).
+    /// Move the list selection to the previous Claude pane (wraps around).
+    /// Refreshing the capture target invalidates a stale peek capture.
     pub fn dashboard_focus_prev(&mut self) {
         let len = self.dashboard_rows().len();
         if len > 0 {
@@ -668,7 +701,7 @@ impl UIState {
         }
     }
 
-    /// Move tile focus to the next Claude pane (wraps around).
+    /// Move the list selection to the next Claude pane (wraps around).
     pub fn dashboard_focus_next(&mut self) {
         let len = self.dashboard_rows().len();
         if len > 0 {
@@ -676,11 +709,40 @@ impl UIState {
         }
     }
 
-    /// tmux target of the currently highlighted dashboard row, if any.
+    /// tmux target of the currently selected dashboard row, if any.
     pub fn get_dashboard_target(&self) -> Option<String> {
         self.dashboard_rows()
             .get(self.dashboard_selected)
             .map(|r| r.target.clone())
+    }
+
+    /// tmux target + capture height of the selected row, used to refresh the
+    /// peek panel content each tick.
+    pub fn dashboard_capture_target(&self) -> Option<(String, i32)> {
+        self.dashboard_rows().get(self.dashboard_selected).map(|r| {
+            (r.target.clone(), i32::try_from(r.height).unwrap_or(i32::MAX))
+        })
+    }
+
+    // =========================================================================
+    // Dashboard peek panel
+    // =========================================================================
+
+    /// Open the peek panel for the selected pane and start a reply buffer.
+    pub fn open_dashboard_peek(&mut self) {
+        if self.dashboard_rows().is_empty() {
+            return;
+        }
+        self.dashboard_peek = true;
+        self.input_buffer.clear();
+        self.input_cursor = 0;
+    }
+
+    /// Close the peek panel, discarding any unsent reply text.
+    pub fn close_dashboard_peek(&mut self) {
+        self.dashboard_peek = false;
+        self.input_buffer.clear();
+        self.input_cursor = 0;
     }
 
     // =========================================================================

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,10 +1,11 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::time::{Duration, Instant};
 
 use ansi_to_tui::IntoText;
 use ratatui::text::Text;
 use ratatui::widgets::ListState;
 
+use crate::agents::{self, AgentSession};
 use crate::config::{BehaviorConfig, Config, HooksConfig, KeyBindings, LayoutConfig, Theme};
 use crate::group::GroupStore;
 
@@ -113,11 +114,14 @@ pub struct TmuxPane {
     pub has_claude: bool,
     /// Latest state reported by Claude Code hooks for this pane, if any.
     pub claude_state: Option<ClaudeState>,
-    /// One-line summary of what Claude is currently doing (e.g. `Edit: src/app.rs`),
-    /// sourced from the hook activity digest. `None` when unknown.
+    // The hook (see [`crate::hook`]) still collects this per-pane context;
+    // it is reserved for an inline tree-view indicator and not yet displayed,
+    // so these carry `#[allow(dead_code)]`.
+    /// One-line summary of what Claude is currently doing (e.g. `Edit: src/app.rs`).
+    #[allow(dead_code)]
     pub claude_activity: Option<String>,
-    /// Unix timestamp (secs) when the current Claude state began. Used to show
-    /// how long a pane has been working/waiting.
+    /// Unix timestamp (secs) when the current Claude state began.
+    #[allow(dead_code)]
     pub claude_state_since: Option<i64>,
     /// Working directory Claude reported for this pane (repo identification).
     #[allow(dead_code)]
@@ -126,6 +130,7 @@ pub struct TmuxPane {
 
 impl TmuxPane {
     /// Seconds elapsed since the current Claude state began, if known.
+    #[allow(dead_code)]
     pub fn claude_state_elapsed_secs(&self) -> Option<i64> {
         self.claude_state_since
             .map(|since| crate::hook::now_secs().saturating_sub(since).max(0))
@@ -178,72 +183,9 @@ pub struct TmuxSession {
 pub enum ViewMode {
     TreeView,
     MultiPreview,
-    /// Full-screen fleet dashboard: every pane running Claude across all
-    /// sessions, sorted by how much it wants attention.
+    /// Full-screen fleet view of Claude Code background sessions (the
+    /// `claude agents` agent view), grouped by working directory.
     Dashboard,
-}
-
-/// Attention groups for the fleet list, mirroring Claude Code's agent view.
-/// Sessions needing the user float to the top.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum DashboardGroup {
-    NeedsInput,
-    Working,
-    Completed,
-}
-
-impl DashboardGroup {
-    /// Which group a pane state belongs to. `None` (running, no hook state yet)
-    /// is treated as Working; `Error` is collected under Completed like the
-    /// agent view does.
-    pub fn of(state: Option<ClaudeState>) -> Self {
-        match state {
-            Some(ClaudeState::Waiting) => Self::NeedsInput,
-            Some(ClaudeState::Working) | None => Self::Working,
-            Some(ClaudeState::Done) | Some(ClaudeState::Error) => Self::Completed,
-        }
-    }
-
-    /// Display order (smaller = higher up): attention first.
-    fn order(self) -> u8 {
-        match self {
-            Self::NeedsInput => 0,
-            Self::Working => 1,
-            Self::Completed => 2,
-        }
-    }
-
-    /// Header label shown above the group.
-    pub fn label(self) -> &'static str {
-        match self {
-            Self::NeedsInput => "Needs input",
-            Self::Working => "Working",
-            Self::Completed => "Completed",
-        }
-    }
-}
-
-/// One row of the fleet dashboard: a single pane running Claude, with the
-/// context needed to render it and to jump to it.
-#[derive(Debug, Clone)]
-pub struct DashboardRow {
-    /// tmux target (`session:window.pane`) for switching to this pane.
-    pub target: String,
-    pub session: String,
-    pub pane_id: String,
-    /// Hook-reported state, or `None` when Claude is detected as running in the
-    /// pane but no hook event has arrived yet (or hooks are not installed).
-    pub state: Option<ClaudeState>,
-    pub activity: Option<String>,
-    pub elapsed_secs: Option<i64>,
-    /// Visible pane height, used to size the peek capture.
-    pub height: u32,
-}
-
-impl DashboardRow {
-    pub fn group(&self) -> DashboardGroup {
-        DashboardGroup::of(self.state)
-    }
 }
 
 /// Focus area in TreeView mode
@@ -471,13 +413,15 @@ pub struct UIState {
     pub multi_session: usize,
     pub multi_window: usize,
 
-    /// Focused tile index in the fleet dashboard grid (`ViewMode::Dashboard`).
-    pub dashboard_selected: usize,
-    /// Captured screen content keyed by tmux target (`session:window.pane`),
-    /// used to populate the peek panel for the selected pane.
-    pub dashboard_captures: HashMap<String, Text<'static>>,
-    /// Whether the peek panel (latest output + reply) is open.
-    pub dashboard_peek: bool,
+    /// Claude Code background sessions shown in the agent view, refreshed from
+    /// `~/.claude/jobs` while the dashboard is open. Order matches the rendered
+    /// (grouped-by-directory) order, so `agent_selected` indexes it directly.
+    pub agent_sessions: Vec<AgentSession>,
+    /// Selected row in the agent view (`ViewMode::Dashboard`).
+    pub agent_selected: usize,
+    /// Set to a session id when the user asks to attach; the UI loop consumes it
+    /// to run `claude attach <id>` and clears it.
+    pub pending_attach: Option<String>,
 
     // Shared state
     pub pane_content: String,
@@ -540,9 +484,9 @@ impl UIState {
             multi_session: 0,
             multi_window: 0,
 
-            dashboard_selected: 0,
-            dashboard_captures: HashMap::new(),
-            dashboard_peek: false,
+            agent_sessions: Vec::new(),
+            agent_selected: 0,
+            pending_attach: None,
 
             pane_content: String::new(),
             pane_content_parsed: None,
@@ -629,120 +573,62 @@ impl UIState {
     }
 
     // =========================================================================
-    // Fleet Dashboard
+    // Agent View (Claude Code background sessions)
     // =========================================================================
 
-    /// Toggle the fleet dashboard on/off. Entering it resets the selection and
-    /// drops stale captures; leaving it also closes any open peek panel.
+    /// Toggle the agent view on/off. Entering it loads the current background
+    /// sessions and resets the selection.
     pub fn toggle_dashboard(&mut self) {
         if self.view_mode == ViewMode::Dashboard {
-            self.close_dashboard_peek();
             self.view_mode = ViewMode::TreeView;
         } else {
-            self.dashboard_selected = 0;
-            self.dashboard_captures.clear();
+            self.agent_selected = 0;
+            self.refresh_agents();
             self.view_mode = ViewMode::Dashboard;
         }
     }
 
-    /// Store a freshly captured pane screen for the peek panel, parsing ANSI.
-    pub fn update_dashboard_capture(&mut self, target: String, content: String) {
-        if let Ok(text) = content.as_bytes().into_text() {
-            self.dashboard_captures.insert(target, text);
+    /// Reload background sessions from `~/.claude/jobs`, keeping the selection
+    /// in range.
+    pub fn refresh_agents(&mut self) {
+        self.agent_sessions = agents::load_agent_sessions();
+        if self.agent_sessions.is_empty() {
+            self.agent_selected = 0;
+        } else {
+            self.agent_selected = self.agent_selected.min(self.agent_sessions.len() - 1);
         }
     }
 
-    /// Captured screen for a pane, if one has arrived yet.
-    pub fn dashboard_capture(&self, target: &str) -> Option<&Text<'static>> {
-        self.dashboard_captures.get(target)
+    pub fn agent_select_prev(&mut self) {
+        self.agent_selected = self.agent_selected.saturating_sub(1);
     }
 
-    /// All panes running Claude across every session: any pane with a hook
-    /// state, plus panes where a Claude process is detected even if no hook
-    /// event has arrived yet (or hooks are not installed) — those show with a
-    /// `None` state. Ordered by attention group (Needs input → Working →
-    /// Completed) and, within a group, longest-in-state first so a stuck/old
-    /// item floats up.
-    pub fn dashboard_rows(&self) -> Vec<DashboardRow> {
-        let mut rows: Vec<DashboardRow> = Vec::new();
-        for session in &self.sessions {
-            for window in &session.windows {
-                for pane in &window.panes {
-                    if pane.claude_state.is_none() && !pane.has_claude {
-                        continue;
-                    }
-                    rows.push(DashboardRow {
-                        target: format!("{}:{}.{}", session.name, window.index, pane.index),
-                        session: session.name.clone(),
-                        pane_id: pane.id.clone(),
-                        state: pane.claude_state,
-                        activity: pane.claude_activity.clone(),
-                        elapsed_secs: pane.claude_state_elapsed_secs(),
-                        height: pane.height,
-                    });
-                }
+    pub fn agent_select_next(&mut self) {
+        if !self.agent_sessions.is_empty() {
+            self.agent_selected = (self.agent_selected + 1).min(self.agent_sessions.len() - 1);
+        }
+    }
+
+    /// Id of the selected background session, for `claude attach <id>`.
+    pub fn selected_agent_id(&self) -> Option<String> {
+        self.agent_sessions
+            .get(self.agent_selected)
+            .map(|s| s.id.clone())
+    }
+
+    /// Per-attention-group counts, used for the agent-view header summary.
+    pub fn agent_group_counts(&self) -> (usize, usize, usize) {
+        let mut needs = 0;
+        let mut working = 0;
+        let mut completed = 0;
+        for s in &self.agent_sessions {
+            match s.state.group() {
+                crate::agents::AgentGroup::NeedsInput => needs += 1,
+                crate::agents::AgentGroup::Working => working += 1,
+                crate::agents::AgentGroup::Completed => completed += 1,
             }
         }
-        rows.sort_by(|a, b| {
-            a.group()
-                .order()
-                .cmp(&b.group().order())
-                .then(b.elapsed_secs.cmp(&a.elapsed_secs))
-        });
-        rows
-    }
-
-    /// Move the list selection to the previous Claude pane (wraps around).
-    /// Refreshing the capture target invalidates a stale peek capture.
-    pub fn dashboard_focus_prev(&mut self) {
-        let len = self.dashboard_rows().len();
-        if len > 0 {
-            self.dashboard_selected = (self.dashboard_selected + len - 1) % len;
-        }
-    }
-
-    /// Move the list selection to the next Claude pane (wraps around).
-    pub fn dashboard_focus_next(&mut self) {
-        let len = self.dashboard_rows().len();
-        if len > 0 {
-            self.dashboard_selected = (self.dashboard_selected + 1) % len;
-        }
-    }
-
-    /// tmux target of the currently selected dashboard row, if any.
-    pub fn get_dashboard_target(&self) -> Option<String> {
-        self.dashboard_rows()
-            .get(self.dashboard_selected)
-            .map(|r| r.target.clone())
-    }
-
-    /// tmux target + capture height of the selected row, used to refresh the
-    /// peek panel content each tick.
-    pub fn dashboard_capture_target(&self) -> Option<(String, i32)> {
-        self.dashboard_rows().get(self.dashboard_selected).map(|r| {
-            (r.target.clone(), i32::try_from(r.height).unwrap_or(i32::MAX))
-        })
-    }
-
-    // =========================================================================
-    // Dashboard peek panel
-    // =========================================================================
-
-    /// Open the peek panel for the selected pane and start a reply buffer.
-    pub fn open_dashboard_peek(&mut self) {
-        if self.dashboard_rows().is_empty() {
-            return;
-        }
-        self.dashboard_peek = true;
-        self.input_buffer.clear();
-        self.input_cursor = 0;
-    }
-
-    /// Close the peek panel, discarding any unsent reply text.
-    pub fn close_dashboard_peek(&mut self) {
-        self.dashboard_peek = false;
-        self.input_buffer.clear();
-        self.input_cursor = 0;
+        (needs, working, completed)
     }
 
     // =========================================================================
@@ -765,7 +651,8 @@ impl UIState {
         match self.view_mode {
             ViewMode::TreeView => self.get_selected_pane_target(),
             ViewMode::MultiPreview => self.get_multi_selected_target(),
-            ViewMode::Dashboard => self.get_dashboard_target(),
+            // Agent-view sessions are not tmux panes; they have no send-keys target.
+            ViewMode::Dashboard => None,
         }
     }
 
@@ -784,7 +671,8 @@ impl UIState {
                 Focus::Panes => self.get_selected_pane_target(),
             },
             ViewMode::MultiPreview => self.get_multi_selected_target(),
-            ViewMode::Dashboard => self.get_dashboard_target(),
+            // The agent view attaches via `claude attach`, not a tmux target.
+            ViewMode::Dashboard => None,
         }
     }
 
@@ -1396,81 +1284,6 @@ mod tests {
 
     /// Build a session with a single window holding the given panes, each
     /// described as `(pane_id, index, claude_state, state_since)`.
-    fn session_with_panes(
-        name: &str,
-        panes: &[(&str, u32, Option<ClaudeState>, Option<i64>)],
-    ) -> TmuxSession {
-        let panes = panes
-            .iter()
-            .map(|(id, index, state, since)| TmuxPane {
-                id: id.to_string(),
-                index: *index,
-                width: 80,
-                height: 24,
-                active: false,
-                current_command: String::new(),
-                pid: 0,
-                has_claude: state.is_some(),
-                claude_state: *state,
-                claude_activity: None,
-                claude_state_since: *since,
-                claude_cwd: None,
-            })
-            .collect();
-        let mut s = session(name);
-        s.windows = vec![TmuxWindow {
-            index: 0,
-            name: "w".to_string(),
-            panes,
-            has_claude: false,
-            claude_state: None,
-        }];
-        s
-    }
-
-    #[test]
-    fn dashboard_rows_sort_by_attention_then_age() {
-        let mut state = UIState::new(Config::default());
-        state.groups = GroupStore::default();
-        // working(old) / working(new) / waiting / done — plus a non-Claude pane.
-        state.sessions = vec![session_with_panes(
-            "s",
-            &[
-                ("%1", 0, Some(ClaudeState::Working), Some(100)), // older working
-                ("%2", 1, Some(ClaudeState::Working), Some(200)), // newer working
-                ("%3", 2, Some(ClaudeState::Waiting), Some(150)),
-                ("%4", 3, Some(ClaudeState::Done), Some(10)),
-                ("%5", 4, None, None), // no Claude -> excluded
-            ],
-        )];
-
-        let rows = state.dashboard_rows();
-        // Waiting first; then the two Working (older = larger elapsed first);
-        // then Done. The non-Claude pane is excluded.
-        let order: Vec<&str> = rows.iter().map(|r| r.pane_id.as_str()).collect();
-        assert_eq!(order, vec!["%3", "%1", "%2", "%4"]);
-        assert_eq!(rows.len(), 4);
-        assert_eq!(rows[0].target, "s:0.2");
-    }
-
-    #[test]
-    fn dashboard_includes_running_panes_without_hook_state() {
-        // A pane with a Claude process but no hook event yet (state None,
-        // has_claude true) must still appear, ranked below any hook state.
-        let mut state = UIState::new(Config::default());
-        state.groups = GroupStore::default();
-        let mut running = session_with_panes("s", &[("%1", 0, None, None)]);
-        running.windows[0].panes[0].has_claude = true;
-        let mut waiting = session_with_panes("t", &[("%2", 0, Some(ClaudeState::Waiting), Some(5))]);
-        waiting.windows[0].panes[0].has_claude = true;
-        state.sessions = vec![running, waiting];
-
-        let rows = state.dashboard_rows();
-        let order: Vec<&str> = rows.iter().map(|r| r.pane_id.as_str()).collect();
-        // Waiting (known state) outranks the unknown running-only pane.
-        assert_eq!(order, vec!["%2", "%1"]);
-        assert_eq!(rows[1].state, None);
-    }
 
     #[test]
     fn ungrouped_sessions_have_no_headers() {

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::time::{Duration, Instant};
 
 use ansi_to_tui::IntoText;
@@ -6,8 +6,21 @@ use ratatui::text::Text;
 use ratatui::widgets::ListState;
 
 use crate::agents::{self, AgentSession};
-use crate::config::{BehaviorConfig, Config, HooksConfig, KeyBindings, LayoutConfig, Theme};
+use crate::config::{
+    AgentsConfig, BehaviorConfig, Config, HooksConfig, KeyBindings, LayoutConfig, Theme,
+};
 use crate::group::GroupStore;
+
+/// State of an on-demand execution summary for a background session.
+#[derive(Debug, Clone)]
+pub enum SummaryStatus {
+    /// A `claude -p` summary is being generated.
+    Pending,
+    /// Summary text ready to show.
+    Ready(String),
+    /// Generation failed (message).
+    Failed(String),
+}
 
 /// Label shown for the implicit group of sessions that have not been assigned
 /// to any user group. Only rendered when at least one session *is* grouped.
@@ -422,6 +435,12 @@ pub struct UIState {
     /// Set to a session id when the user asks to attach; the UI loop consumes it
     /// to run `claude attach <id>` and clears it.
     pub pending_attach: Option<String>,
+    /// Whether the agent-view preview panel (transcript + summary) is shown.
+    pub agent_preview: bool,
+    /// On-demand execution summaries, keyed by session short id.
+    pub agent_summaries: HashMap<String, SummaryStatus>,
+    /// Agent-view config (e.g. summary model).
+    pub agents_config: AgentsConfig,
 
     // Shared state
     pub pane_content: String,
@@ -487,6 +506,9 @@ impl UIState {
             agent_sessions: Vec::new(),
             agent_selected: 0,
             pending_attach: None,
+            agent_preview: false,
+            agent_summaries: HashMap::new(),
+            agents_config: config.agents,
 
             pane_content: String::new(),
             pane_content_parsed: None,
@@ -614,6 +636,35 @@ impl UIState {
         self.agent_sessions
             .get(self.agent_selected)
             .map(|s| s.id.clone())
+    }
+
+    /// The selected background session, if any.
+    pub fn selected_agent(&self) -> Option<&AgentSession> {
+        self.agent_sessions.get(self.agent_selected)
+    }
+
+    /// Toggle the preview panel (transcript + summary) for the selected session.
+    pub fn toggle_agent_preview(&mut self) {
+        self.agent_preview = !self.agent_preview;
+    }
+
+    /// Mark a session's summary as generating.
+    pub fn set_summary_pending(&mut self, id: String) {
+        self.agent_summaries.insert(id, SummaryStatus::Pending);
+    }
+
+    /// Store the outcome of a summary generation.
+    pub fn set_summary_result(&mut self, id: String, result: Result<String, String>) {
+        let status = match result {
+            Ok(text) => SummaryStatus::Ready(text),
+            Err(e) => SummaryStatus::Failed(e),
+        };
+        self.agent_summaries.insert(id, status);
+    }
+
+    /// Current summary status for a session, if any.
+    pub fn summary_status(&self, id: &str) -> Option<&SummaryStatus> {
+        self.agent_summaries.get(id)
     }
 
     /// Per-attention-group counts, used for the agent-view header summary.

--- a/src/app.rs
+++ b/src/app.rs
@@ -191,7 +191,9 @@ pub struct DashboardRow {
     pub target: String,
     pub session: String,
     pub pane_id: String,
-    pub state: ClaudeState,
+    /// Hook-reported state, or `None` when Claude is detected as running in the
+    /// pane but no hook event has arrived yet (or hooks are not installed).
+    pub state: Option<ClaudeState>,
     pub activity: Option<String>,
     pub elapsed_secs: Option<i64>,
 }
@@ -585,33 +587,37 @@ impl UIState {
         }
     }
 
-    /// All panes currently running Claude (or carrying a hook state), across
-    /// every session, sorted by attention priority (Waiting → Error → Working
-    /// → Done) and then by how long they have been in that state (longest
-    /// first), so a stuck/old item floats up within its group.
+    /// All panes running Claude across every session: any pane with a hook
+    /// state, plus panes where a Claude process is detected even if no hook
+    /// event has arrived yet (or hooks are not installed) — those show with a
+    /// `None` state. Sorted by attention priority (Waiting → Error → Working →
+    /// Done → unknown) and then by how long they have been in that state
+    /// (longest first), so a stuck/old item floats up within its group.
     pub fn dashboard_rows(&self) -> Vec<DashboardRow> {
         let mut rows: Vec<DashboardRow> = Vec::new();
         for session in &self.sessions {
             for window in &session.windows {
                 for pane in &window.panes {
-                    let Some(state) = pane.claude_state else {
+                    if pane.claude_state.is_none() && !pane.has_claude {
                         continue;
-                    };
+                    }
                     rows.push(DashboardRow {
                         target: format!("{}:{}.{}", session.name, window.index, pane.index),
                         session: session.name.clone(),
                         pane_id: pane.id.clone(),
-                        state,
+                        state: pane.claude_state,
                         activity: pane.claude_activity.clone(),
                         elapsed_secs: pane.claude_state_elapsed_secs(),
                     });
                 }
             }
         }
+        // A known state outranks an unknown (running-only) one; within a tier,
+        // the longer-running item comes first.
+        let rank = |s: Option<ClaudeState>| s.map(|s| i16::from(s.priority())).unwrap_or(-1);
         rows.sort_by(|a, b| {
-            b.state
-                .priority()
-                .cmp(&a.state.priority())
+            rank(b.state)
+                .cmp(&rank(a.state))
                 .then(b.elapsed_secs.cmp(&a.elapsed_secs))
         });
         rows
@@ -1341,6 +1347,25 @@ mod tests {
         assert_eq!(order, vec!["%3", "%1", "%2", "%4"]);
         assert_eq!(rows.len(), 4);
         assert_eq!(rows[0].target, "s:0.2");
+    }
+
+    #[test]
+    fn dashboard_includes_running_panes_without_hook_state() {
+        // A pane with a Claude process but no hook event yet (state None,
+        // has_claude true) must still appear, ranked below any hook state.
+        let mut state = UIState::new(Config::default());
+        state.groups = GroupStore::default();
+        let mut running = session_with_panes("s", &[("%1", 0, None, None)]);
+        running.windows[0].panes[0].has_claude = true;
+        let mut waiting = session_with_panes("t", &[("%2", 0, Some(ClaudeState::Waiting), Some(5))]);
+        waiting.windows[0].panes[0].has_claude = true;
+        state.sessions = vec![running, waiting];
+
+        let rows = state.dashboard_rows();
+        let order: Vec<&str> = rows.iter().map(|r| r.pane_id.as_str()).collect();
+        // Waiting (known state) outranks the unknown running-only pane.
+        assert_eq!(order, vec!["%2", "%1"]);
+        assert_eq!(rows[1].state, None);
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -435,8 +435,10 @@ pub struct UIState {
     /// Set to a session id when the user asks to attach; the UI loop consumes it
     /// to run `claude attach <id>` and clears it.
     pub pending_attach: Option<String>,
-    /// Whether the agent-view preview panel (transcript + summary) is shown.
+    /// Whether the agent-view transcript preview panel is shown (`p`).
     pub agent_preview: bool,
+    /// Whether the execution-summary popup is open (`s`); independent of preview.
+    pub agent_summary_open: bool,
     /// On-demand execution summaries, keyed by session short id.
     pub agent_summaries: HashMap<String, SummaryStatus>,
     /// Agent-view config (e.g. summary model).
@@ -507,6 +509,7 @@ impl UIState {
             agent_selected: 0,
             pending_attach: None,
             agent_preview: false,
+            agent_summary_open: false,
             agent_summaries: HashMap::new(),
             agents_config: config.agents,
 
@@ -643,9 +646,19 @@ impl UIState {
         self.agent_sessions.get(self.agent_selected)
     }
 
-    /// Toggle the preview panel (transcript + summary) for the selected session.
+    /// Toggle the transcript preview panel for the selected session.
     pub fn toggle_agent_preview(&mut self) {
         self.agent_preview = !self.agent_preview;
+    }
+
+    /// Open the execution-summary popup (independent of the preview panel).
+    pub fn open_agent_summary(&mut self) {
+        self.agent_summary_open = true;
+    }
+
+    /// Close the execution-summary popup.
+    pub fn close_agent_summary(&mut self) {
+        self.agent_summary_open = false;
     }
 
     /// Mark a session's summary as generating.

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::time::{Duration, Instant};
 
 use ansi_to_tui::IntoText;
@@ -423,8 +423,12 @@ pub struct UIState {
     pub multi_session: usize,
     pub multi_window: usize,
 
-    /// Selected row index in the fleet dashboard (`ViewMode::Dashboard`).
+    /// Focused tile index in the fleet dashboard grid (`ViewMode::Dashboard`).
     pub dashboard_selected: usize,
+    /// Live captured screen content per Claude pane, keyed by tmux target
+    /// (`session:window.pane`). Refreshed while the dashboard is open so each
+    /// tile mirrors the agent's real TUI.
+    pub dashboard_captures: HashMap<String, Text<'static>>,
 
     // Shared state
     pub pane_content: String,
@@ -488,6 +492,7 @@ impl UIState {
             multi_window: 0,
 
             dashboard_selected: 0,
+            dashboard_captures: HashMap::new(),
 
             pane_content: String::new(),
             pane_content_parsed: None,
@@ -577,14 +582,46 @@ impl UIState {
     // Fleet Dashboard
     // =========================================================================
 
-    /// Toggle the fleet dashboard on/off. Entering it resets the selection.
+    /// Toggle the fleet dashboard on/off. Entering it resets the focus and
+    /// drops any stale captures so tiles repopulate from scratch.
     pub fn toggle_dashboard(&mut self) {
         if self.view_mode == ViewMode::Dashboard {
             self.view_mode = ViewMode::TreeView;
         } else {
             self.dashboard_selected = 0;
+            self.dashboard_captures.clear();
             self.view_mode = ViewMode::Dashboard;
         }
+    }
+
+    /// tmux targets + visible height of every Claude pane, used to schedule the
+    /// periodic capture that feeds the dashboard tiles.
+    pub fn claude_capture_targets(&self) -> Vec<(String, i32)> {
+        let mut out = Vec::new();
+        for session in &self.sessions {
+            for window in &session.windows {
+                for pane in &window.panes {
+                    if pane.claude_state.is_some() || pane.has_claude {
+                        let target = format!("{}:{}.{}", session.name, window.index, pane.index);
+                        let height = i32::try_from(pane.height).unwrap_or(i32::MAX);
+                        out.push((target, height));
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    /// Store a freshly captured pane screen for the dashboard, parsing ANSI.
+    pub fn update_dashboard_capture(&mut self, target: String, content: String) {
+        if let Ok(text) = content.as_bytes().into_text() {
+            self.dashboard_captures.insert(target, text);
+        }
+    }
+
+    /// Captured screen for a dashboard tile, if one has arrived yet.
+    pub fn dashboard_capture(&self, target: &str) -> Option<&Text<'static>> {
+        self.dashboard_captures.get(target)
     }
 
     /// All panes running Claude across every session: any pane with a hook
@@ -623,14 +660,19 @@ impl UIState {
         rows
     }
 
-    pub fn dashboard_move_up(&mut self) {
-        self.dashboard_selected = self.dashboard_selected.saturating_sub(1);
-    }
-
-    pub fn dashboard_move_down(&mut self) {
+    /// Move tile focus to the previous Claude pane (wraps around).
+    pub fn dashboard_focus_prev(&mut self) {
         let len = self.dashboard_rows().len();
         if len > 0 {
-            self.dashboard_selected = (self.dashboard_selected + 1).min(len - 1);
+            self.dashboard_selected = (self.dashboard_selected + len - 1) % len;
+        }
+    }
+
+    /// Move tile focus to the next Claude pane (wraps around).
+    pub fn dashboard_focus_next(&mut self) {
+        let len = self.dashboard_rows().len();
+        if len > 0 {
+            self.dashboard_selected = (self.dashboard_selected + 1) % len;
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -40,6 +40,7 @@ pub struct Config {
     pub hooks: HooksConfig,
     pub layout: LayoutConfig,
     pub behavior: BehaviorConfig,
+    pub agents: AgentsConfig,
 }
 
 impl Config {
@@ -99,6 +100,27 @@ pub struct PreviewConfig {
     /// Preview refresh interval in milliseconds. `None` lets the CLI flag / the
     /// built-in default (300ms) win, so the precedence is CLI > config > 300.
     pub interval: Option<u64>,
+}
+
+// =============================================================================
+// [agents]
+// =============================================================================
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct AgentsConfig {
+    /// Model passed to `claude -p` when generating an execution summary for the
+    /// selected background session (agent view, `s`). Accepts a `claude`
+    /// `--model` value such as an alias (`haiku`, `sonnet`, `opus`) or a full id.
+    pub summary_model: String,
+}
+
+impl Default for AgentsConfig {
+    fn default() -> Self {
+        Self {
+            summary_model: "haiku".to_string(),
+        }
+    }
 }
 
 // =============================================================================

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod actor;
+mod agents;
 mod app;
 mod cli;
 mod config;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -459,130 +459,163 @@ fn format_elapsed(secs: Option<i64>) -> String {
     }
 }
 
-/// Render the fleet dashboard: a grid of live mirrors, one tile per Claude
-/// pane, each showing the agent's real captured screen. `Tab`/arrows move the
-/// focus between tiles; `Enter` attaches to the focused agent.
+/// Render the fleet dashboard: an agent-view-style list of Claude panes,
+/// grouped by attention (Needs input / Working / Completed). `Space` peeks the
+/// selected pane (latest output + reply), `Enter` attaches.
 fn render_dashboard(frame: &mut Frame, state: &UIState) {
     let area = frame.area();
     let theme = state.theme;
 
     let chunks = Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).split(area);
-    let grid_area = chunks[0];
+    let list_area = chunks[0];
     let status_area = chunks[1];
 
     let rows = state.dashboard_rows();
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(format!(" Claude Fleet ({}) ", rows.len()));
 
     if rows.is_empty() {
-        let block = Block::default()
-            .borders(Borders::ALL)
-            .title(" Claude Fleet (0) ");
         let empty = Paragraph::new(
             "No panes are running Claude.\n\nStart Claude in a pane (and `tmux-deck hook install` for live state).",
         )
         .style(Style::default().fg(theme.unfocus_border))
         .block(block);
-        frame.render_widget(empty, grid_area);
+        frame.render_widget(empty, list_area);
         render_dashboard_status_bar(frame, state, status_area);
         return;
     }
 
-    let focused = state.dashboard_selected.min(rows.len() - 1);
+    let selected = state.dashboard_selected.min(rows.len() - 1);
 
-    // Near-square grid: `cols` columns, enough rows to hold every tile.
-    let cols = (rows.len() as f64).sqrt().ceil() as usize;
-    let grid_rows = rows.len().div_ceil(cols);
-
-    let row_areas = Layout::vertical(
-        std::iter::repeat_n(Constraint::Ratio(1, grid_rows as u32), grid_rows).collect::<Vec<_>>(),
-    )
-    .split(grid_area);
-
-    for (r, row_area) in row_areas.iter().enumerate() {
-        let col_areas = Layout::horizontal(
-            std::iter::repeat_n(Constraint::Ratio(1, cols as u32), cols).collect::<Vec<_>>(),
-        )
-        .split(*row_area);
-        for (c, cell_area) in col_areas.iter().enumerate() {
-            let idx = r * cols + c;
-            if let Some(row) = rows.get(idx) {
-                render_dashboard_tile(frame, state, row, *cell_area, idx == focused);
-            }
+    // Build list items, inserting a header line whenever the group changes.
+    let mut items: Vec<ListItem> = Vec::new();
+    let mut last_group: Option<crate::app::DashboardGroup> = None;
+    for (idx, row) in rows.iter().enumerate() {
+        let group = row.group();
+        if last_group != Some(group) {
+            items.push(ListItem::new(Line::from(Span::styled(
+                group.label().to_string(),
+                Style::default().fg(theme.accent).add_modifier(Modifier::BOLD),
+            ))));
+            last_group = Some(group);
         }
+        items.push(dashboard_row_item(state, row, idx == selected));
     }
 
+    frame.render_widget(List::new(items).block(block), list_area);
     render_dashboard_status_bar(frame, state, status_area);
+
+    if state.dashboard_peek {
+        render_dashboard_peek(frame, state, area, &rows[selected]);
+    }
 }
 
-/// Render one dashboard tile: a bordered mirror of a single Claude pane.
-fn render_dashboard_tile(
-    frame: &mut Frame,
-    state: &UIState,
-    row: &DashboardRow,
-    area: Rect,
-    focused: bool,
-) {
+/// One list row: state marker, session:pane, activity summary, elapsed time.
+fn dashboard_row_item<'a>(state: &UIState, row: &DashboardRow, selected: bool) -> ListItem<'a> {
     let theme = state.theme;
     let (glyph, color) = claude_marker(&state.hooks.claude, row.state, true)
         .unwrap_or_else(|| ("•".to_string(), theme.unfocus_border));
 
-    let border_style = if focused {
-        Style::default().fg(theme.focus_border).add_modifier(Modifier::BOLD)
-    } else {
-        Style::default().fg(color)
-    };
+    let cursor = if selected { "▌" } else { " " };
+    let activity = row.activity.clone().unwrap_or_else(|| "—".to_string());
+    let line = Line::from(vec![
+        Span::styled(format!("{cursor}{glyph} "), Style::default().fg(color)),
+        Span::styled(
+            format!("{:<18} ", format!("{}:{}", row.session, row.pane_id)),
+            Style::default().fg(theme.focus_border),
+        ),
+        Span::raw(format!("{activity:<44} ")),
+        Span::styled(
+            format!("{:>5}", format_elapsed(row.elapsed_secs)),
+            Style::default().fg(theme.unfocus_border),
+        ),
+    ]);
 
-    let mut title = vec![
+    let style = if selected {
+        Style::default().bg(theme.selection_bg).fg(theme.selection_fg)
+    } else {
+        Style::default()
+    };
+    ListItem::new(line).style(style)
+}
+
+/// A rect centred in `area`, sized as a percentage of it.
+fn centered_rect(pct_w: u16, pct_h: u16, area: Rect) -> Rect {
+    let w = area.width * pct_w / 100;
+    let h = area.height * pct_h / 100;
+    Rect {
+        x: area.x + (area.width.saturating_sub(w)) / 2,
+        y: area.y + (area.height.saturating_sub(h)) / 2,
+        width: w,
+        height: h,
+    }
+}
+
+/// Centred peek overlay: the selected pane's latest captured output plus a
+/// reply line. Mirrors the agent view's Space peek.
+fn render_dashboard_peek(frame: &mut Frame, state: &UIState, area: Rect, row: &DashboardRow) {
+    let theme = state.theme;
+    let popup = centered_rect(80, 70, area);
+    frame.render_widget(Clear, popup);
+
+    let outer = Layout::vertical([Constraint::Min(1), Constraint::Length(3)]).split(popup);
+    let content_area = outer[0];
+    let reply_area = outer[1];
+
+    let (glyph, color) = claude_marker(&state.hooks.claude, row.state, true)
+        .unwrap_or_else(|| ("•".to_string(), theme.unfocus_border));
+    let title = Line::from(vec![
         Span::styled(format!(" {glyph} "), Style::default().fg(color)),
         Span::styled(
             format!("{}:{} ", row.session, row.pane_id),
-            Style::default().fg(theme.focus_border),
+            Style::default().fg(theme.focus_border).add_modifier(Modifier::BOLD),
         ),
         Span::styled(
             format!("{} ", claude_state_label(row.state)),
-            Style::default().fg(color).add_modifier(Modifier::BOLD),
+            Style::default().fg(color),
         ),
-    ];
-    if let Some(elapsed) = row.elapsed_secs {
-        title.push(Span::styled(
-            format!("{} ", format_elapsed(Some(elapsed))),
-            Style::default().fg(theme.unfocus_border),
-        ));
-    }
-
-    let block = Block::default()
+    ]);
+    let content_block = Block::default()
         .borders(Borders::ALL)
-        .border_style(border_style)
-        .title(Line::from(title));
-    let inner = block.inner(area);
-    frame.render_widget(block, area);
-
-    // Tile body: tail of the live capture so the latest output is visible.
+        .border_style(Style::default().fg(theme.accent))
+        .title(title);
+    let inner = content_block.inner(content_area);
     let max_lines = inner.height as usize;
     let body = match state.dashboard_capture(&row.target) {
         Some(parsed) if !parsed.lines.is_empty() => {
             let start = parsed.lines.len().saturating_sub(max_lines);
             Text::from(parsed.lines[start..].to_vec())
         }
-        _ => {
-            let hint = row.activity.clone().unwrap_or_else(|| "capturing…".to_string());
-            Text::styled(hint, Style::default().fg(theme.unfocus_border))
-        }
+        _ => Text::styled("capturing…", Style::default().fg(theme.unfocus_border)),
     };
-    frame.render_widget(Paragraph::new(body), inner);
+    frame.render_widget(Paragraph::new(body).block(content_block), content_area);
+
+    // Reply line: typed text is sent to the pane (with Enter) on submit.
+    let reply_block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme.focus_border))
+        .title(" reply → Enter sends · Esc closes · ↑↓ peek · → attach ");
+    let reply = Paragraph::new(Line::from(vec![
+        Span::styled("> ", Style::default().fg(theme.accent)),
+        Span::raw(state.input_buffer.clone()),
+    ]))
+    .block(reply_block);
+    frame.render_widget(reply, reply_area);
 }
 
 fn render_dashboard_status_bar(frame: &mut Frame, state: &UIState, area: Rect) {
     let theme = state.theme;
     let kb = &state.keybindings;
     let status_text = Line::from(vec![
-        Span::styled("Tab", Style::default().fg(theme.focus_border)),
-        Span::raw(":focus "),
+        Span::styled("j/k", Style::default().fg(theme.focus_border)),
+        Span::raw(":move "),
+        Span::styled("Space", Style::default().fg(theme.highlight)),
+        Span::raw(":peek "),
         Span::styled(kb.label(Action::Enter), Style::default().fg(theme.highlight)),
         Span::raw(":attach "),
         Span::styled(kb.label(Action::Dashboard), Style::default().fg(theme.focus_border)),
         Span::raw(":back "),
-        Span::styled(kb.label(Action::Refresh), Style::default().fg(theme.focus_border)),
-        Span::raw(":refresh "),
         Span::styled(kb.label(Action::Quit), Style::default().fg(theme.focus_border)),
         Span::raw(":quit"),
     ]);
@@ -1140,9 +1173,9 @@ mod cursor_alignment_tests {
     }
 
     #[test]
-    fn dashboard_grid_renders_tiles_without_panic() {
-        // Three Claude panes -> a 2-col grid with one trailing empty cell.
-        // Exercises the grid layout, tile capture/tail and focus highlight.
+    fn dashboard_list_and_peek_render_without_panic() {
+        // Three Claude panes across the attention groups. Exercises the grouped
+        // list (headers + selection) and the peek overlay with reply text.
         fn pane(id: &str, idx: u32, st: Option<ClaudeState>) -> TmuxPane {
             TmuxPane {
                 id: id.to_string(),
@@ -1185,6 +1218,12 @@ mod cursor_alignment_tests {
         state.update_dashboard_capture("s:0.0".to_string(), "line1\nline2".to_string());
 
         let mut term = Terminal::new(TestBackend::new(80, 24)).unwrap();
+        // Grouped list.
+        term.draw(|f| render_ui(f, &mut state)).unwrap();
+        // Peek overlay with a reply in progress.
+        state.open_dashboard_peek();
+        state.input_char('h');
+        state.input_char('i');
         term.draw(|f| render_ui(f, &mut state)).unwrap();
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -438,12 +438,14 @@ fn render_tree_status_bar(frame: &mut Frame, state: &UIState, area: Rect) {
 // =============================================================================
 
 /// Short uppercase label for a Claude state, used in the dashboard rows.
-fn claude_state_label(state: ClaudeState) -> &'static str {
+/// `None` (Claude running but no hook state yet) shows as `RUNNING`.
+fn claude_state_label(state: Option<ClaudeState>) -> &'static str {
     match state {
-        ClaudeState::Waiting => "WAITING",
-        ClaudeState::Error => "ERROR",
-        ClaudeState::Working => "WORKING",
-        ClaudeState::Done => "DONE",
+        Some(ClaudeState::Waiting) => "WAITING",
+        Some(ClaudeState::Error) => "ERROR",
+        Some(ClaudeState::Working) => "WORKING",
+        Some(ClaudeState::Done) => "DONE",
+        None => "RUNNING",
     }
 }
 
@@ -494,7 +496,7 @@ fn render_dashboard(frame: &mut Frame, state: &UIState) {
 /// Build a single dashboard row line.
 fn dashboard_item<'a>(state: &UIState, row: &DashboardRow, selected: bool) -> ListItem<'a> {
     let theme = state.theme;
-    let (glyph, color) = claude_marker(&state.hooks.claude, Some(row.state), true)
+    let (glyph, color) = claude_marker(&state.hooks.claude, row.state, true)
         .unwrap_or_else(|| ("•".to_string(), theme.unfocus_border));
 
     let activity = row.activity.clone().unwrap_or_else(|| "—".to_string());

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -459,83 +459,126 @@ fn format_elapsed(secs: Option<i64>) -> String {
     }
 }
 
-/// Render the fleet dashboard: every pane running Claude, sorted by attention
-/// priority, with a one-line activity digest and how long it has been in its
-/// current state. Enter switches to the highlighted pane.
+/// Render the fleet dashboard: a grid of live mirrors, one tile per Claude
+/// pane, each showing the agent's real captured screen. `Tab`/arrows move the
+/// focus between tiles; `Enter` attaches to the focused agent.
 fn render_dashboard(frame: &mut Frame, state: &UIState) {
     let area = frame.area();
     let theme = state.theme;
 
     let chunks = Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).split(area);
-    let list_area = chunks[0];
+    let grid_area = chunks[0];
     let status_area = chunks[1];
 
     let rows = state.dashboard_rows();
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .title(format!(" Claude Fleet ({}) ", rows.len()));
 
     if rows.is_empty() {
-        let empty = Paragraph::new("No panes are running Claude.")
-            .style(Style::default().fg(theme.unfocus_border))
-            .block(block);
-        frame.render_widget(empty, list_area);
-    } else {
-        let selected = state.dashboard_selected.min(rows.len() - 1);
-        let items: Vec<ListItem> = rows
-            .iter()
-            .enumerate()
-            .map(|(idx, row)| dashboard_item(state, row, idx == selected))
-            .collect();
-        frame.render_widget(List::new(items).block(block), list_area);
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .title(" Claude Fleet (0) ");
+        let empty = Paragraph::new(
+            "No panes are running Claude.\n\nStart Claude in a pane (and `tmux-deck hook install` for live state).",
+        )
+        .style(Style::default().fg(theme.unfocus_border))
+        .block(block);
+        frame.render_widget(empty, grid_area);
+        render_dashboard_status_bar(frame, state, status_area);
+        return;
+    }
+
+    let focused = state.dashboard_selected.min(rows.len() - 1);
+
+    // Near-square grid: `cols` columns, enough rows to hold every tile.
+    let cols = (rows.len() as f64).sqrt().ceil() as usize;
+    let grid_rows = rows.len().div_ceil(cols);
+
+    let row_areas = Layout::vertical(
+        std::iter::repeat_n(Constraint::Ratio(1, grid_rows as u32), grid_rows).collect::<Vec<_>>(),
+    )
+    .split(grid_area);
+
+    for (r, row_area) in row_areas.iter().enumerate() {
+        let col_areas = Layout::horizontal(
+            std::iter::repeat_n(Constraint::Ratio(1, cols as u32), cols).collect::<Vec<_>>(),
+        )
+        .split(*row_area);
+        for (c, cell_area) in col_areas.iter().enumerate() {
+            let idx = r * cols + c;
+            if let Some(row) = rows.get(idx) {
+                render_dashboard_tile(frame, state, row, *cell_area, idx == focused);
+            }
+        }
     }
 
     render_dashboard_status_bar(frame, state, status_area);
 }
 
-/// Build a single dashboard row line.
-fn dashboard_item<'a>(state: &UIState, row: &DashboardRow, selected: bool) -> ListItem<'a> {
+/// Render one dashboard tile: a bordered mirror of a single Claude pane.
+fn render_dashboard_tile(
+    frame: &mut Frame,
+    state: &UIState,
+    row: &DashboardRow,
+    area: Rect,
+    focused: bool,
+) {
     let theme = state.theme;
     let (glyph, color) = claude_marker(&state.hooks.claude, row.state, true)
         .unwrap_or_else(|| ("•".to_string(), theme.unfocus_border));
 
-    let activity = row.activity.clone().unwrap_or_else(|| "—".to_string());
-    let line = Line::from(vec![
-        Span::styled(format!("{glyph} "), Style::default().fg(color)),
+    let border_style = if focused {
+        Style::default().fg(theme.focus_border).add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(color)
+    };
+
+    let mut title = vec![
+        Span::styled(format!(" {glyph} "), Style::default().fg(color)),
         Span::styled(
-            format!("{:<7} ", claude_state_label(row.state)),
-            Style::default().fg(color).add_modifier(Modifier::BOLD),
-        ),
-        Span::styled(
-            format!("{}:{:<6} ", row.session, row.pane_id),
+            format!("{}:{} ", row.session, row.pane_id),
             Style::default().fg(theme.focus_border),
         ),
-        Span::raw(format!("{activity:<40} ")),
         Span::styled(
-            format!("{:>5}", format_elapsed(row.elapsed_secs)),
-            Style::default().fg(theme.unfocus_border),
+            format!("{} ", claude_state_label(row.state)),
+            Style::default().fg(color).add_modifier(Modifier::BOLD),
         ),
-    ]);
+    ];
+    if let Some(elapsed) = row.elapsed_secs {
+        title.push(Span::styled(
+            format!("{} ", format_elapsed(Some(elapsed))),
+            Style::default().fg(theme.unfocus_border),
+        ));
+    }
 
-    let style = if selected {
-        Style::default()
-            .bg(theme.selection_bg)
-            .fg(theme.selection_fg)
-            .add_modifier(Modifier::BOLD)
-    } else {
-        Style::default()
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(border_style)
+        .title(Line::from(title));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    // Tile body: tail of the live capture so the latest output is visible.
+    let max_lines = inner.height as usize;
+    let body = match state.dashboard_capture(&row.target) {
+        Some(parsed) if !parsed.lines.is_empty() => {
+            let start = parsed.lines.len().saturating_sub(max_lines);
+            Text::from(parsed.lines[start..].to_vec())
+        }
+        _ => {
+            let hint = row.activity.clone().unwrap_or_else(|| "capturing…".to_string());
+            Text::styled(hint, Style::default().fg(theme.unfocus_border))
+        }
     };
-    ListItem::new(line).style(style)
+    frame.render_widget(Paragraph::new(body), inner);
 }
 
 fn render_dashboard_status_bar(frame: &mut Frame, state: &UIState, area: Rect) {
     let theme = state.theme;
     let kb = &state.keybindings;
     let status_text = Line::from(vec![
-        Span::styled("j/k", Style::default().fg(theme.focus_border)),
-        Span::raw(":move "),
+        Span::styled("Tab", Style::default().fg(theme.focus_border)),
+        Span::raw(":focus "),
         Span::styled(kb.label(Action::Enter), Style::default().fg(theme.highlight)),
-        Span::raw(":jump "),
+        Span::raw(":attach "),
         Span::styled(kb.label(Action::Dashboard), Style::default().fg(theme.focus_border)),
         Span::raw(":back "),
         Span::styled(kb.label(Action::Refresh), Style::default().fg(theme.focus_border)),
@@ -1092,6 +1135,55 @@ mod cursor_alignment_tests {
         // Empty fleet: exercises the empty-state and status-bar paths.
         let mut state = UIState::new(crate::config::Config::default());
         state.view_mode = ViewMode::Dashboard;
+        let mut term = Terminal::new(TestBackend::new(80, 24)).unwrap();
+        term.draw(|f| render_ui(f, &mut state)).unwrap();
+    }
+
+    #[test]
+    fn dashboard_grid_renders_tiles_without_panic() {
+        // Three Claude panes -> a 2-col grid with one trailing empty cell.
+        // Exercises the grid layout, tile capture/tail and focus highlight.
+        fn pane(id: &str, idx: u32, st: Option<ClaudeState>) -> TmuxPane {
+            TmuxPane {
+                id: id.to_string(),
+                index: idx,
+                width: 80,
+                height: 24,
+                active: false,
+                current_command: String::new(),
+                pid: 0,
+                has_claude: true,
+                claude_state: st,
+                claude_activity: Some("Edit: src/app.rs".to_string()),
+                claude_state_since: Some(0),
+                claude_cwd: None,
+            }
+        }
+        let window = TmuxWindow {
+            index: 0,
+            name: "w".to_string(),
+            panes: vec![
+                pane("%1", 0, Some(ClaudeState::Working)),
+                pane("%2", 1, Some(ClaudeState::Waiting)),
+                pane("%3", 2, None),
+            ],
+            has_claude: true,
+            claude_state: Some(ClaudeState::Waiting),
+        };
+        let session = crate::app::TmuxSession {
+            name: "s".to_string(),
+            windows: vec![window],
+            has_claude: true,
+            claude_state: Some(ClaudeState::Waiting),
+            last_attached: 0,
+            activity: 0,
+            group: None,
+        };
+        let mut state = UIState::new(crate::config::Config::default());
+        state.view_mode = ViewMode::Dashboard;
+        state.sessions = vec![session];
+        state.update_dashboard_capture("s:0.0".to_string(), "line1\nline2".to_string());
+
         let mut term = Terminal::new(TestBackend::new(80, 24)).unwrap();
         term.draw(|f| render_ui(f, &mut state)).unwrap();
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -3,9 +3,10 @@ use ratatui::{
     widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph},
 };
 
+use crate::agents::{self, AgentSession, AgentState};
 use crate::app::{
-    ClaudeState, DashboardRow, Focus, InputMode, PopupMode, SessionRow, TmuxPane, TmuxWindow,
-    UIState, UNGROUPED_LABEL, ViewMode,
+    ClaudeState, Focus, InputMode, PopupMode, SessionRow, TmuxPane, TmuxWindow, UIState,
+    UNGROUPED_LABEL, ViewMode,
 };
 use crate::config::{Action, MarkerSet, Theme};
 
@@ -437,47 +438,63 @@ fn render_tree_status_bar(frame: &mut Frame, state: &UIState, area: Rect) {
 // Fleet Dashboard Rendering
 // =============================================================================
 
-/// Short uppercase label for a Claude state, used in the dashboard rows.
-/// `None` (Claude running but no hook state yet) shows as `RUNNING`.
-fn claude_state_label(state: Option<ClaudeState>) -> &'static str {
-    match state {
-        Some(ClaudeState::Waiting) => "WAITING",
-        Some(ClaudeState::Error) => "ERROR",
-        Some(ClaudeState::Working) => "WORKING",
-        Some(ClaudeState::Done) => "DONE",
-        None => "RUNNING",
-    }
-}
-
-/// Human-friendly elapsed time: `12s`, `3m`, `2h`. `None` renders as `-`.
-fn format_elapsed(secs: Option<i64>) -> String {
+/// Human-friendly elapsed time: `12s`, `3m`, `2h`.
+fn format_elapsed(secs: i64) -> String {
     match secs {
-        None => "-".to_string(),
-        Some(s) if s < 60 => format!("{s}s"),
-        Some(s) if s < 3600 => format!("{}m", s / 60),
-        Some(s) => format!("{}h", s / 3600),
+        s if s < 60 => format!("{s}s"),
+        s if s < 3600 => format!("{}m", s / 60),
+        s => format!("{}h", s / 3600),
     }
 }
 
-/// Render the fleet dashboard: an agent-view-style list of Claude panes,
-/// grouped by attention (Needs input / Working / Completed). `Space` peeks the
-/// selected pane (latest output + reply), `Enter` attaches.
+/// Marker glyph + colour for a background-session state, reusing the user's
+/// configured Claude marker set.
+fn agent_marker(markers: &MarkerSet, state: AgentState, theme: &Theme) -> (String, Color) {
+    let mapped = match state {
+        AgentState::Blocked => Some(ClaudeState::Waiting),
+        AgentState::Working => Some(ClaudeState::Working),
+        AgentState::Done => Some(ClaudeState::Done),
+        AgentState::Failed => Some(ClaudeState::Error),
+        AgentState::Idle | AgentState::Stopped | AgentState::Unknown => None,
+    };
+    let has_claude = matches!(state, AgentState::Idle);
+    claude_marker(markers, mapped, has_claude)
+        .unwrap_or_else(|| ("∙".to_string(), theme.unfocus_border))
+}
+
+/// Render the agent view: Claude Code background sessions grouped by working
+/// directory, like `claude agents`. `Enter` attaches to the selected session.
 fn render_dashboard(frame: &mut Frame, state: &UIState) {
     let area = frame.area();
     let theme = state.theme;
 
-    let chunks = Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).split(area);
-    let list_area = chunks[0];
-    let status_area = chunks[1];
+    let chunks = Layout::vertical([
+        Constraint::Length(1),
+        Constraint::Min(1),
+        Constraint::Length(1),
+    ])
+    .split(area);
+    let header_area = chunks[0];
+    let list_area = chunks[1];
+    let status_area = chunks[2];
 
-    let rows = state.dashboard_rows();
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .title(format!(" Claude Fleet ({}) ", rows.len()));
+    // Header: summary counts, like the agent view's "N awaiting input · …".
+    let (needs, working, completed) = state.agent_group_counts();
+    let header = Line::from(vec![
+        Span::styled(" Claude Agents ", Style::default().fg(theme.accent).add_modifier(Modifier::BOLD)),
+        Span::styled(format!("{needs} awaiting input"), Style::default().fg(theme.highlight)),
+        Span::raw(" · "),
+        Span::styled(format!("{working} working"), Style::default().fg(theme.focus_border)),
+        Span::raw(" · "),
+        Span::styled(format!("{completed} completed"), Style::default().fg(theme.unfocus_border)),
+    ]);
+    frame.render_widget(Paragraph::new(header), header_area);
 
-    if rows.is_empty() {
+    let block = Block::default().borders(Borders::ALL);
+
+    if state.agent_sessions.is_empty() {
         let empty = Paragraph::new(
-            "No panes are running Claude.\n\nStart Claude in a pane (and `tmux-deck hook install` for live state).",
+            "No background sessions.\n\nStart one with `claude --bg \"<task>\"` or `/bg` inside a session.",
         )
         .style(Style::default().fg(theme.unfocus_border))
         .block(block);
@@ -486,122 +503,73 @@ fn render_dashboard(frame: &mut Frame, state: &UIState) {
         return;
     }
 
-    let selected = state.dashboard_selected.min(rows.len() - 1);
+    let selected = state.agent_selected.min(state.agent_sessions.len() - 1);
 
-    // Build list items, inserting a header line whenever the group changes.
+    // Build rows, inserting a directory header whenever the cwd changes.
     let mut items: Vec<ListItem> = Vec::new();
-    let mut last_group: Option<crate::app::DashboardGroup> = None;
-    for (idx, row) in rows.iter().enumerate() {
-        let group = row.group();
-        if last_group != Some(group) {
+    let mut last_cwd: Option<&str> = None;
+    for (idx, s) in state.agent_sessions.iter().enumerate() {
+        if last_cwd != Some(s.cwd.as_str()) {
             items.push(ListItem::new(Line::from(Span::styled(
-                group.label().to_string(),
+                agents::abbreviate_path(&s.cwd),
                 Style::default().fg(theme.accent).add_modifier(Modifier::BOLD),
             ))));
-            last_group = Some(group);
+            last_cwd = Some(s.cwd.as_str());
         }
-        items.push(dashboard_row_item(state, row, idx == selected));
+        items.push(agent_row_item(state, s, idx == selected));
     }
 
     frame.render_widget(List::new(items).block(block), list_area);
     render_dashboard_status_bar(frame, state, status_area);
-
-    if state.dashboard_peek {
-        render_dashboard_peek(frame, state, area, &rows[selected]);
-    }
 }
 
-/// One list row: state marker, session:pane, activity summary, elapsed time.
-fn dashboard_row_item<'a>(state: &UIState, row: &DashboardRow, selected: bool) -> ListItem<'a> {
+/// One agent-view row: state marker, name, summary, PR labels, elapsed time.
+fn agent_row_item<'a>(state: &UIState, session: &AgentSession, selected: bool) -> ListItem<'a> {
     let theme = state.theme;
-    let (glyph, color) = claude_marker(&state.hooks.claude, row.state, true)
-        .unwrap_or_else(|| ("•".to_string(), theme.unfocus_border));
+    let (mut glyph, color) = agent_marker(&state.hooks.claude, session.state, &theme);
+    // A finished/exited worker is shown with the agent view's "∙" dot shape.
+    if !session.alive {
+        glyph = "∙".to_string();
+    }
 
     let cursor = if selected { "▌" } else { " " };
-    let activity = row.activity.clone().unwrap_or_else(|| "—".to_string());
-    let line = Line::from(vec![
+    let mut spans = vec![
         Span::styled(format!("{cursor}{glyph} "), Style::default().fg(color)),
         Span::styled(
-            format!("{:<18} ", format!("{}:{}", row.session, row.pane_id)),
+            format!("{:<24} ", truncate(&session.name, 24)),
             Style::default().fg(theme.focus_border),
         ),
-        Span::raw(format!("{activity:<44} ")),
-        Span::styled(
-            format!("{:>5}", format_elapsed(row.elapsed_secs)),
-            Style::default().fg(theme.unfocus_border),
-        ),
-    ]);
+        Span::raw(format!("{:<46} ", truncate(&session.summary, 46))),
+    ];
+    if !session.prs.is_empty() {
+        let label = if session.prs.len() == 1 {
+            format!("PR #{}", session.prs[0].id)
+        } else {
+            format!("{} PRs", session.prs.len())
+        };
+        spans.push(Span::styled(format!("{label:<8} "), Style::default().fg(theme.success)));
+    }
+    spans.push(Span::styled(
+        format!("{:>4}", format_elapsed(session.elapsed_secs)),
+        Style::default().fg(theme.unfocus_border),
+    ));
 
     let style = if selected {
         Style::default().bg(theme.selection_bg).fg(theme.selection_fg)
     } else {
         Style::default()
     };
-    ListItem::new(line).style(style)
+    ListItem::new(Line::from(spans)).style(style)
 }
 
-/// A rect centred in `area`, sized as a percentage of it.
-fn centered_rect(pct_w: u16, pct_h: u16, area: Rect) -> Rect {
-    let w = area.width * pct_w / 100;
-    let h = area.height * pct_h / 100;
-    Rect {
-        x: area.x + (area.width.saturating_sub(w)) / 2,
-        y: area.y + (area.height.saturating_sub(h)) / 2,
-        width: w,
-        height: h,
+/// Truncate to `max` display chars with an ellipsis, padding handled by caller.
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() > max {
+        let head: String = s.chars().take(max - 1).collect();
+        format!("{head}…")
+    } else {
+        s.to_string()
     }
-}
-
-/// Centred peek overlay: the selected pane's latest captured output plus a
-/// reply line. Mirrors the agent view's Space peek.
-fn render_dashboard_peek(frame: &mut Frame, state: &UIState, area: Rect, row: &DashboardRow) {
-    let theme = state.theme;
-    let popup = centered_rect(80, 70, area);
-    frame.render_widget(Clear, popup);
-
-    let outer = Layout::vertical([Constraint::Min(1), Constraint::Length(3)]).split(popup);
-    let content_area = outer[0];
-    let reply_area = outer[1];
-
-    let (glyph, color) = claude_marker(&state.hooks.claude, row.state, true)
-        .unwrap_or_else(|| ("•".to_string(), theme.unfocus_border));
-    let title = Line::from(vec![
-        Span::styled(format!(" {glyph} "), Style::default().fg(color)),
-        Span::styled(
-            format!("{}:{} ", row.session, row.pane_id),
-            Style::default().fg(theme.focus_border).add_modifier(Modifier::BOLD),
-        ),
-        Span::styled(
-            format!("{} ", claude_state_label(row.state)),
-            Style::default().fg(color),
-        ),
-    ]);
-    let content_block = Block::default()
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(theme.accent))
-        .title(title);
-    let inner = content_block.inner(content_area);
-    let max_lines = inner.height as usize;
-    let body = match state.dashboard_capture(&row.target) {
-        Some(parsed) if !parsed.lines.is_empty() => {
-            let start = parsed.lines.len().saturating_sub(max_lines);
-            Text::from(parsed.lines[start..].to_vec())
-        }
-        _ => Text::styled("capturing…", Style::default().fg(theme.unfocus_border)),
-    };
-    frame.render_widget(Paragraph::new(body).block(content_block), content_area);
-
-    // Reply line: typed text is sent to the pane (with Enter) on submit.
-    let reply_block = Block::default()
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(theme.focus_border))
-        .title(" reply → Enter sends · Esc closes · ↑↓ peek · → attach ");
-    let reply = Paragraph::new(Line::from(vec![
-        Span::styled("> ", Style::default().fg(theme.accent)),
-        Span::raw(state.input_buffer.clone()),
-    ]))
-    .block(reply_block);
-    frame.render_widget(reply, reply_area);
 }
 
 fn render_dashboard_status_bar(frame: &mut Frame, state: &UIState, area: Rect) {
@@ -610,8 +578,6 @@ fn render_dashboard_status_bar(frame: &mut Frame, state: &UIState, area: Rect) {
     let status_text = Line::from(vec![
         Span::styled("j/k", Style::default().fg(theme.focus_border)),
         Span::raw(":move "),
-        Span::styled("Space", Style::default().fg(theme.highlight)),
-        Span::raw(":peek "),
         Span::styled(kb.label(Action::Enter), Style::default().fg(theme.highlight)),
         Span::raw(":attach "),
         Span::styled(kb.label(Action::Dashboard), Style::default().fg(theme.focus_border)),
@@ -1114,12 +1080,11 @@ mod cursor_alignment_tests {
 
     #[test]
     fn format_elapsed_scales_units() {
-        assert_eq!(format_elapsed(None), "-");
-        assert_eq!(format_elapsed(Some(0)), "0s");
-        assert_eq!(format_elapsed(Some(59)), "59s");
-        assert_eq!(format_elapsed(Some(60)), "1m");
-        assert_eq!(format_elapsed(Some(3599)), "59m");
-        assert_eq!(format_elapsed(Some(3600)), "1h");
+        assert_eq!(format_elapsed(0), "0s");
+        assert_eq!(format_elapsed(59), "59s");
+        assert_eq!(format_elapsed(60), "1m");
+        assert_eq!(format_elapsed(3599), "59m");
+        assert_eq!(format_elapsed(3600), "1h");
     }
 
     /// 白背景（カーソルブロック）のセルの (x, y) を返す。
@@ -1165,7 +1130,7 @@ mod cursor_alignment_tests {
 
     #[test]
     fn dashboard_renders_without_panic() {
-        // Empty fleet: exercises the empty-state and status-bar paths.
+        // Empty agent view: exercises the empty-state, header and status bar.
         let mut state = UIState::new(crate::config::Config::default());
         state.view_mode = ViewMode::Dashboard;
         let mut term = Terminal::new(TestBackend::new(80, 24)).unwrap();
@@ -1173,57 +1138,30 @@ mod cursor_alignment_tests {
     }
 
     #[test]
-    fn dashboard_list_and_peek_render_without_panic() {
-        // Three Claude panes across the attention groups. Exercises the grouped
-        // list (headers + selection) and the peek overlay with reply text.
-        fn pane(id: &str, idx: u32, st: Option<ClaudeState>) -> TmuxPane {
-            TmuxPane {
+    fn agent_view_renders_grouped_sessions_without_panic() {
+        // Sessions across two directories and several states. Exercises the
+        // directory headers, state markers, PR labels and selection highlight.
+        fn sess(id: &str, name: &str, state: AgentState, cwd: &str, prs: &[&str]) -> AgentSession {
+            AgentSession {
                 id: id.to_string(),
-                index: idx,
-                width: 80,
-                height: 24,
-                active: false,
-                current_command: String::new(),
-                pid: 0,
-                has_claude: true,
-                claude_state: st,
-                claude_activity: Some("Edit: src/app.rs".to_string()),
-                claude_state_since: Some(0),
-                claude_cwd: None,
+                name: name.to_string(),
+                state,
+                summary: "did some work".to_string(),
+                cwd: cwd.to_string(),
+                elapsed_secs: 120,
+                prs: prs.iter().map(|p| crate::agents::PrRef { id: p.to_string() }).collect(),
+                alive: true,
             }
         }
-        let window = TmuxWindow {
-            index: 0,
-            name: "w".to_string(),
-            panes: vec![
-                pane("%1", 0, Some(ClaudeState::Working)),
-                pane("%2", 1, Some(ClaudeState::Waiting)),
-                pane("%3", 2, None),
-            ],
-            has_claude: true,
-            claude_state: Some(ClaudeState::Waiting),
-        };
-        let session = crate::app::TmuxSession {
-            name: "s".to_string(),
-            windows: vec![window],
-            has_claude: true,
-            claude_state: Some(ClaudeState::Waiting),
-            last_attached: 0,
-            activity: 0,
-            group: None,
-        };
         let mut state = UIState::new(crate::config::Config::default());
         state.view_mode = ViewMode::Dashboard;
-        state.sessions = vec![session];
-        state.update_dashboard_capture("s:0.0".to_string(), "line1\nline2".to_string());
+        state.agent_sessions = vec![
+            sess("a1", "telemetry fix", AgentState::Blocked, "/home/u/proj-a", &["12"]),
+            sess("a2", "refactor", AgentState::Working, "/home/u/proj-a", &[]),
+            sess("b1", "docs", AgentState::Done, "/home/u/proj-b", &["3", "4"]),
+        ];
 
-        let mut term = Terminal::new(TestBackend::new(80, 24)).unwrap();
-        // Grouped list.
-        term.draw(|f| render_ui(f, &mut state)).unwrap();
-        // Peek overlay with a reply in progress.
-        state.open_dashboard_peek();
-        state.input_char('h');
-        state.input_char('i');
+        let mut term = Terminal::new(TestBackend::new(100, 24)).unwrap();
         term.draw(|f| render_ui(f, &mut state)).unwrap();
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -505,6 +505,15 @@ fn render_dashboard(frame: &mut Frame, state: &UIState) {
 
     let selected = state.agent_selected.min(state.agent_sessions.len() - 1);
 
+    // With the preview open, split the body into list | preview.
+    let (list_rect, preview_rect) = if state.agent_preview {
+        let cols = Layout::horizontal([Constraint::Percentage(45), Constraint::Percentage(55)])
+            .split(list_area);
+        (cols[0], Some(cols[1]))
+    } else {
+        (list_area, None)
+    };
+
     // Build rows, inserting a directory header whenever the cwd changes.
     let mut items: Vec<ListItem> = Vec::new();
     let mut last_cwd: Option<&str> = None;
@@ -519,8 +528,69 @@ fn render_dashboard(frame: &mut Frame, state: &UIState) {
         items.push(agent_row_item(state, s, idx == selected));
     }
 
-    frame.render_widget(List::new(items).block(block), list_area);
+    frame.render_widget(List::new(items).block(block), list_rect);
+    if let Some(preview_rect) = preview_rect {
+        render_agent_preview(frame, state, &state.agent_sessions[selected], preview_rect);
+    }
     render_dashboard_status_bar(frame, state, status_area);
+}
+
+/// Preview panel for the selected session: an execution summary section (on
+/// demand, via `claude -p`) above a tail of the conversation transcript.
+fn render_agent_preview(frame: &mut Frame, state: &UIState, session: &AgentSession, area: Rect) {
+    let theme = state.theme;
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme.accent))
+        .title(format!(" {} ", truncate(&session.name, area.width.saturating_sub(4) as usize)));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    // Summary section (top) + transcript (bottom).
+    let rows = Layout::vertical([Constraint::Length(7), Constraint::Min(1)]).split(inner);
+    let summary_area = rows[0];
+    let transcript_area = rows[1];
+
+    // --- Summary ---
+    let mut summary_lines = vec![Line::from(Span::styled(
+        "Summary (s to generate)",
+        Style::default().fg(theme.highlight).add_modifier(Modifier::BOLD),
+    ))];
+    match state.summary_status(&session.id) {
+        Some(crate::app::SummaryStatus::Pending) => {
+            summary_lines.push(Line::from(Span::styled(
+                "summarizing…",
+                Style::default().fg(theme.unfocus_border),
+            )));
+        }
+        Some(crate::app::SummaryStatus::Ready(text)) => {
+            for l in text.lines().take(5) {
+                summary_lines.push(Line::from(l.to_string()));
+            }
+        }
+        Some(crate::app::SummaryStatus::Failed(e)) => {
+            summary_lines.push(Line::from(Span::styled(
+                format!("summary failed: {e}"),
+                Style::default().fg(theme.error),
+            )));
+        }
+        None => {
+            summary_lines.push(Line::from(Span::styled(
+                "press s to summarize this session",
+                Style::default().fg(theme.unfocus_border),
+            )));
+        }
+    }
+    frame.render_widget(Paragraph::new(summary_lines), summary_area);
+
+    // --- Transcript tail ---
+    let tail = session
+        .transcript_path
+        .as_ref()
+        .map(|p| agents::transcript_tail(p, transcript_area.height as usize))
+        .unwrap_or_else(|| vec!["(no transcript)".to_string()]);
+    let lines: Vec<Line> = tail.into_iter().map(Line::from).collect();
+    frame.render_widget(Paragraph::new(lines), transcript_area);
 }
 
 /// One agent-view row: state marker, name, summary, PR labels, elapsed time.
@@ -580,6 +650,10 @@ fn render_dashboard_status_bar(frame: &mut Frame, state: &UIState, area: Rect) {
         Span::raw(":move "),
         Span::styled(kb.label(Action::Enter), Style::default().fg(theme.highlight)),
         Span::raw(":attach "),
+        Span::styled("p", Style::default().fg(theme.focus_border)),
+        Span::raw(":preview "),
+        Span::styled("s", Style::default().fg(theme.focus_border)),
+        Span::raw(":summary "),
         Span::styled(kb.label(Action::Dashboard), Style::default().fg(theme.focus_border)),
         Span::raw(":back "),
         Span::styled(kb.label(Action::Quit), Style::default().fg(theme.focus_border)),
@@ -1151,6 +1225,7 @@ mod cursor_alignment_tests {
                 elapsed_secs: 120,
                 prs: prs.iter().map(|p| crate::agents::PrRef { id: p.to_string() }).collect(),
                 alive: true,
+                transcript_path: None,
             }
         }
         let mut state = UIState::new(crate::config::Config::default());

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -533,64 +533,97 @@ fn render_dashboard(frame: &mut Frame, state: &UIState) {
         render_agent_preview(frame, state, &state.agent_sessions[selected], preview_rect);
     }
     render_dashboard_status_bar(frame, state, status_area);
+
+    // The summary popup is independent of the preview panel.
+    if state.agent_summary_open {
+        render_agent_summary_popup(frame, state, &state.agent_sessions[selected], area);
+    }
 }
 
-/// Preview panel for the selected session: an execution summary section (on
-/// demand, via `claude -p`) above a tail of the conversation transcript.
+/// Style a reconstructed transcript line by its leading glyph: user prompts,
+/// assistant text and tool calls each get a distinct colour.
+fn transcript_line_style(line: &str, theme: &Theme) -> Style {
+    match line.chars().next() {
+        Some('▸') => Style::default().fg(theme.highlight), // user
+        Some('⏺') => Style::default().fg(theme.success),   // tool call
+        Some('●') => Style::default().fg(theme.focus_border), // assistant
+        _ => Style::default(),
+    }
+}
+
+/// Preview panel for the selected session: a tail of the conversation
+/// transcript, coloured by role. (The execution summary is a separate popup.)
 fn render_agent_preview(frame: &mut Frame, state: &UIState, session: &AgentSession, area: Rect) {
     let theme = state.theme;
     let block = Block::default()
         .borders(Borders::ALL)
         .border_style(Style::default().fg(theme.accent))
-        .title(format!(" {} ", truncate(&session.name, area.width.saturating_sub(4) as usize)));
+        .title(format!(
+            " {} ",
+            truncate(&session.name, area.width.saturating_sub(4) as usize)
+        ));
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
-    // Summary section (top) + transcript (bottom).
-    let rows = Layout::vertical([Constraint::Length(7), Constraint::Min(1)]).split(inner);
-    let summary_area = rows[0];
-    let transcript_area = rows[1];
-
-    // --- Summary ---
-    let mut summary_lines = vec![Line::from(Span::styled(
-        "Summary (s to generate)",
-        Style::default().fg(theme.highlight).add_modifier(Modifier::BOLD),
-    ))];
-    match state.summary_status(&session.id) {
-        Some(crate::app::SummaryStatus::Pending) => {
-            summary_lines.push(Line::from(Span::styled(
-                "summarizing…",
-                Style::default().fg(theme.unfocus_border),
-            )));
-        }
-        Some(crate::app::SummaryStatus::Ready(text)) => {
-            for l in text.lines().take(5) {
-                summary_lines.push(Line::from(l.to_string()));
-            }
-        }
-        Some(crate::app::SummaryStatus::Failed(e)) => {
-            summary_lines.push(Line::from(Span::styled(
-                format!("summary failed: {e}"),
-                Style::default().fg(theme.error),
-            )));
-        }
-        None => {
-            summary_lines.push(Line::from(Span::styled(
-                "press s to summarize this session",
-                Style::default().fg(theme.unfocus_border),
-            )));
-        }
-    }
-    frame.render_widget(Paragraph::new(summary_lines), summary_area);
-
-    // --- Transcript tail ---
     let tail = session
         .transcript_path
         .as_ref()
-        .map(|p| agents::transcript_tail(p, transcript_area.height as usize))
+        .map(|p| agents::transcript_tail(p, inner.height as usize))
         .unwrap_or_else(|| vec!["(no transcript)".to_string()]);
-    let lines: Vec<Line> = tail.into_iter().map(Line::from).collect();
-    frame.render_widget(Paragraph::new(lines), transcript_area);
+    let lines: Vec<Line> = tail
+        .into_iter()
+        .map(|l| {
+            let style = transcript_line_style(&l, &theme);
+            Line::from(Span::styled(l, style))
+        })
+        .collect();
+    frame.render_widget(Paragraph::new(lines), inner);
+}
+
+/// Centred popup showing the on-demand execution summary for a session,
+/// independent of the preview panel. Opened with `s`, closed with `Esc`.
+fn render_agent_summary_popup(
+    frame: &mut Frame,
+    state: &UIState,
+    session: &AgentSession,
+    area: Rect,
+) {
+    let theme = state.theme;
+    let popup = centered_rect(70, 50, area);
+    frame.render_widget(Clear, popup);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme.highlight))
+        .title(format!(" Summary — {} ", truncate(&session.name, 30)))
+        .title_bottom(Line::from(" s:regenerate · Esc:close ").centered());
+
+    let body = match state.summary_status(&session.id) {
+        Some(crate::app::SummaryStatus::Pending) => {
+            Text::styled("summarizing…", Style::default().fg(theme.unfocus_border))
+        }
+        Some(crate::app::SummaryStatus::Ready(text)) => Text::raw(text.clone()),
+        Some(crate::app::SummaryStatus::Failed(e)) => {
+            Text::styled(format!("summary failed: {e}"), Style::default().fg(theme.error))
+        }
+        None => Text::styled(
+            "press s to summarize",
+            Style::default().fg(theme.unfocus_border),
+        ),
+    };
+    frame.render_widget(Paragraph::new(body).block(block).wrap(ratatui::widgets::Wrap { trim: false }), popup);
+}
+
+/// A rect centred in `area`, sized as a percentage of it.
+fn centered_rect(pct_w: u16, pct_h: u16, area: Rect) -> Rect {
+    let w = area.width * pct_w / 100;
+    let h = area.height * pct_h / 100;
+    Rect {
+        x: area.x + (area.width.saturating_sub(w)) / 2,
+        y: area.y + (area.height.saturating_sub(h)) / 2,
+        width: w,
+        height: h,
+    }
 }
 
 /// One agent-view row: state marker, name, summary, PR labels, elapsed time.
@@ -1237,6 +1270,15 @@ mod cursor_alignment_tests {
         ];
 
         let mut term = Terminal::new(TestBackend::new(100, 24)).unwrap();
+        term.draw(|f| render_ui(f, &mut state)).unwrap();
+
+        // With the transcript preview split open.
+        state.agent_preview = true;
+        term.draw(|f| render_ui(f, &mut state)).unwrap();
+
+        // With the (independent) summary popup open.
+        state.agent_summary_open = true;
+        state.set_summary_pending("a1".to_string());
         term.draw(|f| render_ui(f, &mut state)).unwrap();
     }
 }


### PR DESCRIPTION
## 概要
`d` のフリートビューを、**Claude Code のバックグラウンドセッション(`claude agents` のエージェントビュー)を表示・管理するビュー**に作り直しました。tmux ペインではなく、`~/.claude/jobs/<id>/state.json`(`claude agents` と同じソース)を読みます。

スクリーンショットで頂いた「こういうセッションを表示して管理したい」に対応するものです。当初 tmux ペインを対象にしていたのが根本的な間違いでした。

## 実装
- **新規 `agents` モジュール**: 各 `jobs/<id>/state.json`(state / name / needs / detail / cwd / children=PR)+ `daemon/roster.json`(プロセス生存)を読む。「最終更新」は state.json の mtime。`CLAUDE_CONFIG_DIR` 対応。
- **エージェントビュー(`d`)**: バックグラウンドセッションを**作業ディレクトリでグループ化**(最も要対応のディレクトリが上)。ヘッダーに集計(`N awaiting input · M working · K completed`)。各行: 状態マーカー / 名前 / 1行要約 / PRラベル / 経過時間。プロセス終了済みは `∙`。
- **アタッチ(Enter)**: TUI を一時退避 → `claude attach <id>` に端末を明け渡し → デタッチで TUI 復帰。`j/k` 選択、`d` でツリーに戻る。
- 表示中は毎tick `~/.claude/jobs` から再読込。

## スコープ(今回)
**表示 + アタッチまで**(合意どおり)。停止・返信・ディスパッチは未実装。

## 実データ検証
ローカルの `~/.claude/jobs`(8セッション)を読み、名前・状態・PR・cwd・経過・生存を正しく取得することを確認済み。

## テスト
- state パース / ディレクトリ・グルーピングのソート / パス短縮 / エージェントビュー描画スモーク
- `cargo test --all --locked` 50件 / `cargo clippy -D warnings` クリーン

## 補足
- tmux ペインの hook 連携(#19/#20)は引き続きデータ収集するが、本ビューでは非表示(将来のツリー内インライン表示用に保持)。
- 状態の語彙: state.json は `blocked`(=入力待ち)/`working`/`idle`/`done`/`failed`/`stopped`。
🤖 Generated with [Claude Code](https://claude.com/claude-code)
