### PR TITLE
feat(agents): screen preview mode via minimal ANSI emulator (v toggle)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1052,6 +1052,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ directories = "6.0.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"
+unicode-width = "0.2"
 
 [[bin]]
 name = "tmux-deck"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Monitoring multi session Realtime preview.
 - 📄 Easy management Windows and Panes between Sessions
 - 👀 Realtime Preview
 - 🤖 Claude Code status markers (working / waiting / done) driven by hooks
-- 🛰️ Claude agent view (`d`): lists Claude Code background sessions (`claude agents`) grouped by directory — state, name, summary, PRs, elapsed. `Enter` attaches via `claude attach`, `p` toggles a transcript preview, `s` generates an execution summary (`claude -p`)
+- 🛰️ Claude agent view (`d`): lists Claude Code background sessions (`claude agents`) grouped by directory — state, name, summary, PRs, elapsed. `Enter` attaches via `claude attach`, `p` toggles a preview (`v` switches transcript ↔ reconstructed screen), `s` generates an execution summary (`claude -p`)
 - ⚙️ Easy Configure
 
 # Quick Start

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -21,6 +21,10 @@ interval = 50
 # selected background session in the agent view (press `s`). Accepts any
 # `claude --model` value: an alias (haiku / sonnet / opus) or a full model id.
 summary_model = "haiku"
+# Default preview mode in the agent view (`p`): "transcript" reconstructs the
+# conversation; "screen" reconstructs the terminal screen from `claude logs`.
+# Toggle at runtime with `v`.
+preview_mode = "transcript"
 
 # -----------------------------------------------------------------------------
 [theme]

--- a/src/actor/ui_actor.rs
+++ b/src/actor/ui_actor.rs
@@ -55,6 +55,13 @@ pub struct UIActor {
     /// Results of background `claude -p` summary jobs: (session id, Ok(text)/Err).
     agent_summary_tx: mpsc::Sender<(String, Result<String, String>)>,
     agent_summary_rx: mpsc::Receiver<(String, Result<String, String>)>,
+    /// Results of background `claude logs` fetches for the screen preview.
+    agent_logs_tx: mpsc::Sender<(String, Vec<u8>)>,
+    agent_logs_rx: mpsc::Receiver<(String, Vec<u8>)>,
+    /// Sessions whose `claude logs` fetch is in flight, and when each id was
+    /// last fetched (to throttle refresh).
+    logs_inflight: std::collections::HashSet<String>,
+    logs_fetched_at: std::collections::HashMap<String, std::time::Instant>,
 }
 
 impl UIActor {
@@ -72,6 +79,7 @@ impl UIActor {
         spawn_key_event_poller(key_tx);
 
         let (agent_summary_tx, agent_summary_rx) = mpsc::channel(8);
+        let (agent_logs_tx, agent_logs_rx) = mpsc::channel(8);
 
         Self {
             terminal,
@@ -84,6 +92,10 @@ impl UIActor {
             refresh_control,
             agent_summary_tx,
             agent_summary_rx,
+            agent_logs_tx,
+            agent_logs_rx,
+            logs_inflight: std::collections::HashSet::new(),
+            logs_fetched_at: std::collections::HashMap::new(),
         }
     }
 
@@ -122,6 +134,13 @@ impl UIActor {
                     self.state.set_summary_result(id, result);
                 }
 
+                // Completed `claude logs` fetches for the screen preview.
+                Some((id, bytes)) = self.agent_logs_rx.recv() => {
+                    self.logs_inflight.remove(&id);
+                    self.logs_fetched_at.insert(id.clone(), std::time::Instant::now());
+                    self.state.update_agent_logs(id, bytes);
+                }
+
                 // TmuxActor responses
                 Some(response) = self.tmux_res_rx.recv() => {
                     self.handle_tmux_response(response);
@@ -148,8 +167,13 @@ impl UIActor {
                                             .await;
                                     }
                                 }
-                                // The agent view reloads background sessions from disk.
-                                ViewMode::Dashboard => self.state.refresh_agents(),
+                                // The agent view reloads background sessions from
+                                // disk and, in screen-preview mode, refreshes the
+                                // selected session's `claude logs`.
+                                ViewMode::Dashboard => {
+                                    self.state.refresh_agents();
+                                    self.maybe_fetch_logs();
+                                }
                                 ViewMode::MultiPreview => {}
                             }
                         }
@@ -365,6 +389,10 @@ impl UIActor {
                     self.state.toggle_agent_preview();
                     return Ok(false);
                 }
+                KeyCode::Char('v') if self.state.view_mode == ViewMode::Dashboard => {
+                    self.state.cycle_preview_mode();
+                    return Ok(false);
+                }
                 KeyCode::Char('s') if self.state.view_mode == ViewMode::Dashboard => {
                     self.state.open_agent_summary();
                     self.request_agent_summary();
@@ -511,6 +539,44 @@ impl UIActor {
         }
         self.state.refresh_agents();
         Ok(())
+    }
+
+    /// In screen-preview mode, fetch the selected session's `claude logs`
+    /// output in the background, throttled per session. No-op unless the
+    /// preview is open in screen mode.
+    fn maybe_fetch_logs(&mut self) {
+        if !self.state.agent_preview
+            || self.state.agent_preview_mode != crate::app::PreviewMode::Screen
+        {
+            return;
+        }
+        let Some(session) = self.state.selected_agent() else {
+            return;
+        };
+        let id = session.id.clone();
+        if self.logs_inflight.contains(&id) {
+            return;
+        }
+        // Throttle: refetch a given session at most every ~3s.
+        let fresh = self
+            .logs_fetched_at
+            .get(&id)
+            .is_some_and(|t| t.elapsed() < Duration::from_secs(3));
+        if fresh {
+            return;
+        }
+        self.logs_inflight.insert(id.clone());
+        let tx = self.agent_logs_tx.clone();
+        tokio::spawn(async move {
+            let bytes = tokio::process::Command::new("claude")
+                .arg("logs")
+                .arg(&id)
+                .output()
+                .await
+                .map(|o| o.stdout)
+                .unwrap_or_default();
+            let _ = tx.send((id, bytes)).await;
+        });
     }
 
     /// Kick off an execution summary for the selected background session by

--- a/src/app.rs
+++ b/src/app.rs
@@ -11,6 +11,31 @@ use crate::config::{
 };
 use crate::group::GroupStore;
 
+/// How the agent-view preview panel renders the selected session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PreviewMode {
+    /// Reconstructed conversation from the transcript JSONL (fast, plain).
+    Transcript,
+    /// Reconstructed terminal screen from `claude logs` (faithful, heavier).
+    Screen,
+}
+
+impl PreviewMode {
+    pub fn from_str(s: &str) -> Self {
+        match s {
+            "screen" => Self::Screen,
+            _ => Self::Transcript,
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Transcript => "transcript",
+            Self::Screen => "screen",
+        }
+    }
+}
+
 /// State of an on-demand execution summary for a background session.
 #[derive(Debug, Clone)]
 pub enum SummaryStatus {
@@ -435,12 +460,17 @@ pub struct UIState {
     /// Set to a session id when the user asks to attach; the UI loop consumes it
     /// to run `claude attach <id>` and clears it.
     pub pending_attach: Option<String>,
-    /// Whether the agent-view transcript preview panel is shown (`p`).
+    /// Whether the agent-view preview panel is shown (`p`).
     pub agent_preview: bool,
+    /// How the preview renders (transcript vs screen); toggled with `v`.
+    pub agent_preview_mode: PreviewMode,
     /// Whether the execution-summary popup is open (`s`); independent of preview.
     pub agent_summary_open: bool,
     /// On-demand execution summaries, keyed by session short id.
     pub agent_summaries: HashMap<String, SummaryStatus>,
+    /// Cached `claude logs` output (raw PTY bytes) per session id, for the
+    /// screen preview mode.
+    pub agent_logs: HashMap<String, Vec<u8>>,
     /// Agent-view config (e.g. summary model).
     pub agents_config: AgentsConfig,
 
@@ -509,8 +539,10 @@ impl UIState {
             agent_selected: 0,
             pending_attach: None,
             agent_preview: false,
+            agent_preview_mode: PreviewMode::from_str(&config.agents.preview_mode),
             agent_summary_open: false,
             agent_summaries: HashMap::new(),
+            agent_logs: HashMap::new(),
             agents_config: config.agents,
 
             pane_content: String::new(),
@@ -646,9 +678,27 @@ impl UIState {
         self.agent_sessions.get(self.agent_selected)
     }
 
-    /// Toggle the transcript preview panel for the selected session.
+    /// Toggle the preview panel for the selected session.
     pub fn toggle_agent_preview(&mut self) {
         self.agent_preview = !self.agent_preview;
+    }
+
+    /// Switch the preview between transcript and screen rendering (`v`).
+    pub fn cycle_preview_mode(&mut self) {
+        self.agent_preview_mode = match self.agent_preview_mode {
+            PreviewMode::Transcript => PreviewMode::Screen,
+            PreviewMode::Screen => PreviewMode::Transcript,
+        };
+    }
+
+    /// Store freshly fetched `claude logs` output for the screen preview.
+    pub fn update_agent_logs(&mut self, id: String, bytes: Vec<u8>) {
+        self.agent_logs.insert(id, bytes);
+    }
+
+    /// Cached `claude logs` bytes for a session, if fetched.
+    pub fn agent_logs_for(&self, id: &str) -> Option<&Vec<u8>> {
+        self.agent_logs.get(id)
     }
 
     /// Open the execution-summary popup (independent of the preview panel).

--- a/src/config.rs
+++ b/src/config.rs
@@ -113,12 +113,17 @@ pub struct AgentsConfig {
     /// selected background session (agent view, `s`). Accepts a `claude`
     /// `--model` value such as an alias (`haiku`, `sonnet`, `opus`) or a full id.
     pub summary_model: String,
+    /// Default preview mode in the agent view: `transcript` (reconstructed
+    /// conversation) or `screen` (reconstructed terminal screen via
+    /// `claude logs`). Toggle at runtime with `v`.
+    pub preview_mode: String,
 }
 
 impl Default for AgentsConfig {
     fn default() -> Self {
         Self {
             summary_model: "haiku".to_string(),
+            preview_mode: "transcript".to_string(),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod cli;
 mod config;
 mod group;
 mod hook;
+mod termscreen;
 mod ui;
 
 use std::io;

--- a/src/termscreen.rs
+++ b/src/termscreen.rs
@@ -1,0 +1,396 @@
+//! A minimal ANSI/VT screen emulator.
+//!
+//! Background sessions have no tmux pane to `capture-pane`, so the "screen"
+//! preview mode feeds the raw PTY byte stream from `claude logs <id>` through
+//! this emulator to reconstruct the on-screen grid, then renders it with
+//! colours — approximating what the session's terminal looks like.
+//!
+//! This is intentionally a *subset* of a real terminal: it handles the
+//! sequences `claude logs` actually emits (SGR colours, absolute/relative
+//! cursor motion, erase, CR/LF/BS/TAB, and printable text with wide-char
+//! awareness) and ignores the rest (mode toggles, OSC titles, …). Faithful
+//! enough for a preview, not a real terminal.
+
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span, Text};
+use unicode_width::UnicodeWidthChar;
+
+#[derive(Clone)]
+struct Cell {
+    ch: char,
+    style: Style,
+}
+
+impl Default for Cell {
+    fn default() -> Self {
+        Self {
+            ch: ' ',
+            style: Style::default(),
+        }
+    }
+}
+
+struct Screen {
+    grid: Vec<Vec<Cell>>,
+    w: usize,
+    h: usize,
+    row: usize,
+    col: usize,
+    style: Style,
+}
+
+impl Screen {
+    fn new(w: usize, h: usize) -> Self {
+        Self {
+            grid: vec![vec![Cell::default(); w]; h],
+            w,
+            h,
+            row: 0,
+            col: 0,
+            style: Style::default(),
+        }
+    }
+
+    fn scroll_up(&mut self) {
+        self.grid.remove(0);
+        self.grid.push(vec![Cell::default(); self.w]);
+    }
+
+    fn newline(&mut self) {
+        self.row += 1;
+        if self.row >= self.h {
+            self.scroll_up();
+            self.row = self.h - 1;
+        }
+    }
+
+    fn put(&mut self, c: char) {
+        let cw = c.width().unwrap_or(0);
+        if cw == 0 {
+            return; // control / zero-width
+        }
+        if self.col >= self.w {
+            self.col = 0;
+            self.newline();
+        }
+        if self.row < self.h && self.col < self.w {
+            self.grid[self.row][self.col] = Cell {
+                ch: c,
+                style: self.style,
+            };
+        }
+        self.col += cw;
+    }
+
+    fn clamp(&mut self) {
+        if self.row >= self.h {
+            self.row = self.h - 1;
+        }
+        if self.col >= self.w {
+            self.col = self.w - 1;
+        }
+    }
+
+    fn erase_line(&mut self, mode: u16) {
+        if self.row >= self.h {
+            return;
+        }
+        let (from, to) = match mode {
+            1 => (0, self.col.min(self.w.saturating_sub(1)) + 1),
+            2 => (0, self.w),
+            _ => (self.col, self.w), // 0: cursor to end
+        };
+        for c in from..to.min(self.w) {
+            self.grid[self.row][c] = Cell::default();
+        }
+    }
+
+    fn erase_display(&mut self, mode: u16) {
+        match mode {
+            2 | 3 => {
+                for r in 0..self.h {
+                    self.grid[r] = vec![Cell::default(); self.w];
+                }
+            }
+            1 => {
+                for r in 0..self.row.min(self.h) {
+                    self.grid[r] = vec![Cell::default(); self.w];
+                }
+                self.erase_line(1);
+            }
+            _ => {
+                // 0: cursor to end of screen
+                self.erase_line(0);
+                for r in (self.row + 1)..self.h {
+                    self.grid[r] = vec![Cell::default(); self.w];
+                }
+            }
+        }
+    }
+
+    /// Apply an SGR (`ESC [ ... m`) parameter list to the current style.
+    fn sgr(&mut self, params: &[u16]) {
+        let mut i = 0;
+        if params.is_empty() {
+            self.style = Style::default();
+            return;
+        }
+        while i < params.len() {
+            match params[i] {
+                0 => self.style = Style::default(),
+                1 => self.style = self.style.add_modifier(Modifier::BOLD),
+                2 => self.style = self.style.add_modifier(Modifier::DIM),
+                3 => self.style = self.style.add_modifier(Modifier::ITALIC),
+                4 => self.style = self.style.add_modifier(Modifier::UNDERLINED),
+                7 => self.style = self.style.add_modifier(Modifier::REVERSED),
+                22 => self.style = self.style.remove_modifier(Modifier::BOLD | Modifier::DIM),
+                23 => self.style = self.style.remove_modifier(Modifier::ITALIC),
+                24 => self.style = self.style.remove_modifier(Modifier::UNDERLINED),
+                27 => self.style = self.style.remove_modifier(Modifier::REVERSED),
+                30..=37 => self.style = self.style.fg(basic_color(params[i] - 30)),
+                39 => self.style = self.style.fg(Color::Reset),
+                40..=47 => self.style = self.style.bg(basic_color(params[i] - 40)),
+                49 => self.style = self.style.bg(Color::Reset),
+                90..=97 => self.style = self.style.fg(basic_color(params[i] - 90 + 8)),
+                100..=107 => self.style = self.style.bg(basic_color(params[i] - 100 + 8)),
+                38 | 48 => {
+                    let is_fg = params[i] == 38;
+                    // 38;5;n  or  38;2;r;g;b
+                    if let Some(&kind) = params.get(i + 1) {
+                        if kind == 5 {
+                            if let Some(&n) = params.get(i + 2) {
+                                let col = Color::Indexed(n as u8);
+                                self.style = if is_fg {
+                                    self.style.fg(col)
+                                } else {
+                                    self.style.bg(col)
+                                };
+                            }
+                            i += 2;
+                        } else if kind == 2 {
+                            if let (Some(&r), Some(&g), Some(&b)) =
+                                (params.get(i + 2), params.get(i + 3), params.get(i + 4))
+                            {
+                                let col = Color::Rgb(r as u8, g as u8, b as u8);
+                                self.style = if is_fg {
+                                    self.style.fg(col)
+                                } else {
+                                    self.style.bg(col)
+                                };
+                            }
+                            i += 4;
+                        }
+                    }
+                }
+                _ => {}
+            }
+            i += 1;
+        }
+    }
+
+    fn into_text(self) -> Text<'static> {
+        let lines = self
+            .grid
+            .into_iter()
+            .map(|row| {
+                // Coalesce adjacent cells with the same style into spans.
+                let mut spans: Vec<Span> = Vec::new();
+                let mut cur = String::new();
+                let mut cur_style: Option<Style> = None;
+                for cell in row {
+                    match cur_style {
+                        Some(s) if s == cell.style => cur.push(cell.ch),
+                        _ => {
+                            if let Some(s) = cur_style {
+                                spans.push(Span::styled(std::mem::take(&mut cur), s));
+                            }
+                            cur.push(cell.ch);
+                            cur_style = Some(cell.style);
+                        }
+                    }
+                }
+                if let Some(s) = cur_style {
+                    spans.push(Span::styled(cur, s));
+                }
+                Line::from(spans)
+            })
+            .collect::<Vec<_>>();
+        Text::from(lines)
+    }
+}
+
+fn basic_color(n: u16) -> Color {
+    Color::Indexed(n as u8)
+}
+
+/// Parse `input` (a raw PTY byte stream) into a `width`×`height` screen and
+/// render it as styled ratatui text.
+pub fn render_screen(input: &[u8], width: u16, height: u16) -> Text<'static> {
+    let w = (width as usize).max(1);
+    let h = (height as usize).max(1);
+    let mut s = Screen::new(w, h);
+
+    let text = String::from_utf8_lossy(input);
+    let mut chars = text.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        match c {
+            '\x1b' => match chars.peek() {
+                Some('[') => {
+                    chars.next();
+                    parse_csi(&mut chars, &mut s);
+                }
+                Some(']') => {
+                    chars.next();
+                    // OSC: skip until BEL or ESC \
+                    while let Some(&n) = chars.peek() {
+                        chars.next();
+                        if n == '\x07' {
+                            break;
+                        }
+                        if n == '\x1b' {
+                            chars.next(); // consume the following '\'
+                            break;
+                        }
+                    }
+                }
+                // Other ESC sequences (e.g. ESC =, ESC >): consume one byte.
+                Some(_) => {
+                    chars.next();
+                }
+                None => {}
+            },
+            '\r' => s.col = 0,
+            '\n' => s.newline(),
+            '\x08' => s.col = s.col.saturating_sub(1),
+            '\t' => {
+                s.col = ((s.col / 8) + 1) * 8;
+                if s.col >= w {
+                    s.col = w - 1;
+                }
+            }
+            c => s.put(c),
+        }
+    }
+    s.into_text()
+}
+
+/// Parse a CSI body (after `ESC [`) up to and including its final byte, and
+/// apply it to the screen.
+fn parse_csi(chars: &mut std::iter::Peekable<std::str::Chars>, s: &mut Screen) {
+    let mut private = false;
+    let mut buf = String::new();
+    let mut final_byte = '\0';
+    while let Some(&c) = chars.peek() {
+        chars.next();
+        match c {
+            '?' | '>' | '!' => private = true,
+            '0'..='9' | ';' | ':' => buf.push(c),
+            ' '..='/' => { /* intermediate bytes, ignore */ }
+            '@'..='~' => {
+                final_byte = c;
+                break;
+            }
+            _ => break,
+        }
+    }
+    let params: Vec<u16> = buf
+        .split(';')
+        .map(|p| p.split(':').next().unwrap_or("").parse().unwrap_or(0))
+        .collect();
+    let p0 = *params.first().unwrap_or(&0);
+    let n = p0.max(1) as usize;
+
+    if private {
+        // Private modes (?25h/l, ?2026h/l, ?1049h/l, …): nothing to render.
+        // Treat entering the alternate screen as a clear so stale content goes.
+        if final_byte == 'h' && params.first() == Some(&1049) {
+            s.erase_display(2);
+            s.row = 0;
+            s.col = 0;
+        }
+        return;
+    }
+
+    match final_byte {
+        'm' => s.sgr(&params),
+        'H' | 'f' => {
+            s.row = (p0.max(1) as usize) - 1;
+            s.col = (*params.get(1).unwrap_or(&1)).max(1) as usize - 1;
+            s.clamp();
+        }
+        'A' => s.row = s.row.saturating_sub(n),
+        'B' => {
+            s.row += n;
+            s.clamp();
+        }
+        'C' => {
+            s.col += n;
+            s.clamp();
+        }
+        'D' => s.col = s.col.saturating_sub(n),
+        'G' => {
+            s.col = (p0.max(1) as usize) - 1;
+            s.clamp();
+        }
+        'd' => {
+            s.row = (p0.max(1) as usize) - 1;
+            s.clamp();
+        }
+        'J' => s.erase_display(p0),
+        'K' => s.erase_line(p0),
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn plain(text: &Text) -> String {
+        text.lines
+            .iter()
+            .map(|l| {
+                l.spans
+                    .iter()
+                    .map(|s| s.content.as_ref())
+                    .collect::<String>()
+                    .trim_end()
+                    .to_string()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+            .trim_end()
+            .to_string()
+    }
+
+    #[test]
+    fn plain_text_and_newlines() {
+        let t = render_screen(b"hello\r\nworld", 20, 4);
+        assert_eq!(plain(&t), "hello\nworld");
+    }
+
+    #[test]
+    fn absolute_cursor_positioning() {
+        // Move to row 2 col 3 (1-based) and write.
+        let t = render_screen(b"\x1b[2;3HX", 10, 3);
+        assert_eq!(plain(&t), "\n  X");
+    }
+
+    #[test]
+    fn erase_line_and_overwrite() {
+        // Write "aaaa", carriage-return, erase line, write "b".
+        let t = render_screen(b"aaaa\r\x1b[2Kb", 6, 1);
+        assert_eq!(plain(&t), "b");
+    }
+
+    #[test]
+    fn sgr_colour_sets_style() {
+        let t = render_screen(b"\x1b[31mR\x1b[0mN", 6, 1);
+        let line = &t.lines[0];
+        // First span is the red "R".
+        assert_eq!(line.spans[0].content.as_ref(), "R");
+        assert_eq!(line.spans[0].style.fg, Some(Color::Indexed(1)));
+    }
+}
+

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -551,33 +551,55 @@ fn transcript_line_style(line: &str, theme: &Theme) -> Style {
     }
 }
 
-/// Preview panel for the selected session: a tail of the conversation
-/// transcript, coloured by role. (The execution summary is a separate popup.)
+/// Preview panel for the selected session. Two modes (toggle with `v`):
+/// `transcript` reconstructs the conversation (coloured by role); `screen`
+/// reconstructs the terminal screen from `claude logs` via the emulator.
 fn render_agent_preview(frame: &mut Frame, state: &UIState, session: &AgentSession, area: Rect) {
     let theme = state.theme;
+    let mode = state.agent_preview_mode;
+    let title = format!(
+        " {} [{}] ",
+        truncate(&session.name, area.width.saturating_sub(12) as usize),
+        mode.label()
+    );
     let block = Block::default()
         .borders(Borders::ALL)
         .border_style(Style::default().fg(theme.accent))
-        .title(format!(
-            " {} ",
-            truncate(&session.name, area.width.saturating_sub(4) as usize)
-        ));
+        .title(title)
+        .title_bottom(Line::from(" v:mode ").right_aligned());
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
-    let tail = session
-        .transcript_path
-        .as_ref()
-        .map(|p| agents::transcript_tail(p, inner.height as usize))
-        .unwrap_or_else(|| vec!["(no transcript)".to_string()]);
-    let lines: Vec<Line> = tail
-        .into_iter()
-        .map(|l| {
-            let style = transcript_line_style(&l, &theme);
-            Line::from(Span::styled(l, style))
-        })
-        .collect();
-    frame.render_widget(Paragraph::new(lines), inner);
+    match mode {
+        crate::app::PreviewMode::Transcript => {
+            let tail = session
+                .transcript_path
+                .as_ref()
+                .map(|p| agents::transcript_tail(p, inner.height as usize))
+                .unwrap_or_else(|| vec!["(no transcript)".to_string()]);
+            let lines: Vec<Line> = tail
+                .into_iter()
+                .map(|l| {
+                    let style = transcript_line_style(&l, &theme);
+                    Line::from(Span::styled(l, style))
+                })
+                .collect();
+            frame.render_widget(Paragraph::new(lines), inner);
+        }
+        crate::app::PreviewMode::Screen => match state.agent_logs_for(&session.id) {
+            Some(bytes) if !bytes.is_empty() => {
+                let screen = crate::termscreen::render_screen(bytes, inner.width, inner.height);
+                frame.render_widget(Paragraph::new(screen), inner);
+            }
+            _ => {
+                frame.render_widget(
+                    Paragraph::new("loading screen… (claude logs)")
+                        .style(Style::default().fg(theme.unfocus_border)),
+                    inner,
+                );
+            }
+        },
+    }
 }
 
 /// Centred popup showing the on-demand execution summary for a session,
@@ -685,6 +707,8 @@ fn render_dashboard_status_bar(frame: &mut Frame, state: &UIState, area: Rect) {
         Span::raw(":attach "),
         Span::styled("p", Style::default().fg(theme.focus_border)),
         Span::raw(":preview "),
+        Span::styled("v", Style::default().fg(theme.focus_border)),
+        Span::raw(":mode "),
         Span::styled("s", Style::default().fg(theme.focus_border)),
         Span::raw(":summary "),
         Span::styled(kb.label(Action::Dashboard), Style::default().fg(theme.focus_border)),


### PR DESCRIPTION
## 概要
Agent view のプレビューに「**本物の画面再現(screen)**」モードを追加します。既存の transcript モードと**`v` で切り替え**、config で既定を選べます。

> **Stacked PR**: base は #26(`fix/dashboard-include-running-panes`)。#26 マージ後に base は繰り上がります。

## 背景(なぜ自前エミュレータか)
`vt100` / `vte` / `avt` 等の端末エミュレータcrateは**すべて `unicode-width 0.1` を要求**し、`ratatui 0.29` の `unicode-width = "=0.2.0"` 固定と衝突して導入不可でした(各版で `cargo build` 解決失敗を確認)。そのため**外部依存なしの最小ANSIエミュレータ**を自前実装しています。

## 実装
- **`termscreen` モジュール**: 最小ANSI/VTスクリーンエミュレータ。SGR色(16/256/truecolor)・カーソル絶対/相対移動・消去(J/K)・CR/LF/BS/TAB・全角文字幅・代替画面クリアを処理し、その他(モード/OSC)は無視。グリッドを ratatui の色付き `Text` に変換。ユニットテスト付き。
- **screen モード**: `claude logs <id>`(生PTYバイト列)をバックグラウンドで取得→エミュレータに通して描画。取得はセッション別キャッシュ + **screenプレビュー表示中のみ ~3秒間隔**にスロットリング。
- **切り替え**: `[agents] preview_mode = "transcript" | "screen"`(既定 transcript)+ 実行中 `v` キー。プレビュー枠タイトルに現在モード表示。
- `unicode-width` を直接依存に追加(ratatui固定と同じ 0.2 系なので解決に影響なし)。

## 操作(Agent view)
`p` プレビュー / `v` モード切替(transcript ↔ screen)/ `s` サマリー / `Enter` アタッチ

## 限界(正直)
- `claude logs` はフルスクリーンTUIの再描画ストリーム。元の端末サイズが不明なため、プレビュー枠サイズで再構成します。**capture-pane(TreeView)ほど完璧ではなく**、レイアウトに粗が出る場合あり。好みで `v` で transcript に戻せます。

## テスト
- エミュレータ単体4件 + 既存。実 `claude logs` 出力での再構成も確認(行番号/diff等が位置どおり再現)。
- `cargo test --all --locked` 54件 / `cargo clippy -D warnings` クリーン
🤖 Generated with [Claude Code](https://claude.com/claude-code)
